### PR TITLE
feat: anti-Workday UX improvements

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -529,13 +529,13 @@ function LoginPage() {
               Time is money.
             </h1>
             <div className="text-base text-zinc-400 space-y-2">
-              <div>Log in one time, and STAY logged in.</div>
-              <div>Effortless navigation.</div>
-              <div>Frictionless clock in.</div>
-              <div>Real time visualized earnings.</div>
-              <div>Find the best-matched jobs.</div>
-              <div>Taxes filed instantly with AI.</div>
-              <div>AI assisted HR support with Swifty.</div>
+              <div>No 9-step PTO requests. <span className="text-white">One form, done.</span></div>
+              <div>Clock in with one tap. <span className="text-white">Not seven clicks.</span></div>
+              <div>PTO balance visible <span className="text-white">right on your dashboard.</span></div>
+              <div>Real-time earnings. <span className="text-white">Not end-of-month guesses.</span></div>
+              <div>Stay logged in. <span className="text-white">Forever.</span></div>
+              <div>AI-filed taxes. <span className="text-white">AI-matched jobs.</span></div>
+              <div>Press <kbd className="px-1.5 py-0.5 rounded bg-white/10 text-white text-xs font-mono">Space</kbd> to clock in. <span className="text-white">Zero friction.</span></div>
             </div>
           </div>
         </div>
@@ -714,13 +714,13 @@ function SignupPage() {
               Time is money.
             </h1>
             <div className="text-base text-zinc-400 space-y-2">
-              <div>Log in one time, and STAY logged in.</div>
-              <div>Effortless navigation.</div>
-              <div>Frictionless clock in.</div>
-              <div>Real time visualized earnings.</div>
-              <div>Find the best-matched jobs.</div>
-              <div>Taxes filed instantly with AI.</div>
-              <div>AI assisted HR support with Swifty.</div>
+              <div>No 9-step PTO requests. <span className="text-white">One form, done.</span></div>
+              <div>Clock in with one tap. <span className="text-white">Not seven clicks.</span></div>
+              <div>PTO balance visible <span className="text-white">right on your dashboard.</span></div>
+              <div>Real-time earnings. <span className="text-white">Not end-of-month guesses.</span></div>
+              <div>Stay logged in. <span className="text-white">Forever.</span></div>
+              <div>AI-filed taxes. <span className="text-white">AI-matched jobs.</span></div>
+              <div>Press <kbd className="px-1.5 py-0.5 rounded bg-white/10 text-white text-xs font-mono">Space</kbd> to clock in. <span className="text-white">Zero friction.</span></div>
             </div>
           </div>
         </div>
@@ -910,6 +910,14 @@ export default function App() {
   const [taxFormData, setTaxFormData] = useState<any | null>(null)
   const [taxLoading, setTaxLoading] = useState(false)
   const [selectedDoc, setSelectedDoc] = useState<{ label: string; content: string } | null>(null)
+
+  // Leave request state (anti-Workday: 3-field form instead of 9-step flow)
+  const [showLeaveModal, setShowLeaveModal] = useState(false)
+  const [leaveType, setLeaveType] = useState('Vacation')
+  const [leaveStart, setLeaveStart] = useState('')
+  const [leaveEnd, setLeaveEnd] = useState('')
+  const [leaveNote, setLeaveNote] = useState('')
+  const [myLeaveRequests, setMyLeaveRequests] = useState<Array<{ type: string; start: string; end: string; days: number; status: string; note: string }>>([])
 
   const orgData = {
     id: 'ceo',
@@ -1237,6 +1245,25 @@ export default function App() {
       setShowLootDrop(true)
     }
   }
+
+  // Spacebar = clock in/out when on clock view and not typing
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.code !== 'Space' || e.repeat) return
+      const tag = (document.activeElement as HTMLElement)?.tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
+      if (activeView !== 'clock') return
+      e.preventDefault()
+      if (!isClockedIn) {
+        handleClockIn()
+      } else if (!isOnBreak) {
+        handleClockOut()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeView, isClockedIn, isOnBreak])
 
   const handleSendChat = async () => {
     const msg = chatMessage.trim()
@@ -1577,7 +1604,7 @@ export default function App() {
                         </span>
                       </div>
 
-                  <div className="flex flex-wrap gap-3">
+                  <div className="flex flex-wrap gap-3 items-center">
                     {!isClockedIn && (
                       <button
                         onClick={handleClockIn}
@@ -1585,6 +1612,11 @@ export default function App() {
                       >
                         Clock in
                       </button>
+                    )}
+                    {!isClockedIn && (
+                      <span className="text-xs text-zinc-600 flex items-center gap-1">
+                        or press <kbd className="px-1.5 py-0.5 rounded bg-white/10 text-white/60 font-mono text-[10px]">Space</kbd>
+                      </span>
                     )}
                     {isClockedIn && !isOnBreak && (
                       <>
@@ -1695,6 +1727,30 @@ export default function App() {
                   </div>
                 </div>
 
+                {/* My Schedule: week at a glance (Workday makes you hunt for this) */}
+                <div className="glass rounded-3xl p-6">
+                  <div className="flex items-center justify-between mb-4">
+                    <div className="text-sm uppercase tracking-[2px] text-white">My Schedule This Week</div>
+                    <button onClick={() => setActiveView('schedules')} className="text-xs text-zinc-500 hover:text-white underline underline-offset-2">Full schedule →</button>
+                  </div>
+                  <div className="grid grid-cols-7 gap-2">
+                    {(['Mon','Tue','Wed','Thu','Fri','Sat','Sun']).map((day, i) => {
+                      const isToday = new Date().getDay() === (i === 6 ? 0 : i + 1)
+                      const shift = i < 5 ? (i % 2 === 0 ? '6–2' : '2–10') : null
+                      return (
+                        <div key={day} className={`rounded-xl p-2 text-center text-xs ${isToday ? 'border' : 'bg-white/5'}`}
+                          style={isToday ? { borderColor: 'var(--accent-color)', backgroundColor: 'var(--accent-color-dim)' } : undefined}>
+                          <div className={`font-semibold mb-1 ${isToday ? '' : 'text-zinc-500'}`} style={isToday ? { color: 'var(--accent-color)' } : undefined}>{day}</div>
+                          {shift ? (
+                            <div className="text-[10px]" style={{ color: isToday ? 'var(--accent-color)' : undefined }}>{shift}</div>
+                          ) : (
+                            <div className="text-[10px] text-zinc-700">Off</div>
+                          )}
+                        </div>
+                      )
+                    })}
+                  </div>
+                </div>
               </div>
 
               {/* Right sidebar: This pay period + Real Time Rewards */}
@@ -1732,6 +1788,42 @@ export default function App() {
                   >
                     See rewards →
                   </button>
+                </div>
+
+                {/* PTO Balance card */}
+                <div className="glass rounded-3xl p-8 flex-1">
+                  <div className="text-sm uppercase tracking-[2px] text-white mb-3">PTO Balance</div>
+                  <div className="text-3xl font-bold mb-1 neon-green">
+                    {(80 - myLeaveRequests.filter(r => r.status === 'Approved').reduce((sum, r) => sum + r.days, 0) + parseFloat(((todayTotalMs / 3600000) / 30).toFixed(1))).toFixed(1)}
+                    <span className="text-sm font-normal text-zinc-400 ml-1">hrs</span>
+                  </div>
+                  <div className="text-xs text-zinc-500 mb-3">Accruing at 1 hr per 30 worked</div>
+                  <button
+                    onClick={() => { setActiveView('leaves'); setShowLeaveModal(true) }}
+                    className="text-sm px-3 py-1.5 rounded-xl font-medium w-full text-center transition-all hover:opacity-80"
+                    style={{ backgroundColor: 'var(--accent-color)', color: '#000' }}
+                  >
+                    Request Time Off →
+                  </button>
+                </div>
+
+                {/* Next Payday countdown */}
+                <div className="glass rounded-3xl p-8 flex-1">
+                  <div className="text-sm uppercase tracking-[2px] text-white mb-3">Next Payday</div>
+                  {(() => {
+                    const daysLeft = Math.max(0, Math.ceil((period.end.getTime() - now.getTime()) / 86400000))
+                    const pctThrough = Math.min(1, (now.getTime() - period.start.getTime()) / (14 * 86400000))
+                    return (
+                      <>
+                        <div className="text-3xl font-bold mb-1 neon-green">{daysLeft}<span className="text-sm font-normal text-zinc-400 ml-1">days</span></div>
+                        <div className="text-xs text-zinc-500 mb-3">{period.end.toLocaleDateString([], { month: 'short', day: 'numeric' })}</div>
+                        <div className="h-1.5 bg-white/10 rounded-full overflow-hidden">
+                          <div className="h-full rounded-full transition-all" style={{ width: `${Math.round(pctThrough * 100)}%`, backgroundColor: 'var(--accent-color)' }} />
+                        </div>
+                        <div className="text-xs text-zinc-600 mt-1">{Math.round(pctThrough * 100)}% through pay period</div>
+                      </>
+                    )
+                  })()}
                 </div>
               </aside>
             </div>
@@ -2011,30 +2103,158 @@ export default function App() {
           )}
           {activeView === 'leaves' && (
             <div className="max-w-5xl mx-auto space-y-6">
+              {/* Request Time Off modal */}
+              {showLeaveModal && (
+                <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80" onClick={() => setShowLeaveModal(false)}>
+                  <div className="glass rounded-3xl p-8 w-full max-w-md border border-white/20 shadow-2xl" onClick={e => e.stopPropagation()}>
+                    <div className="flex items-center justify-between mb-6">
+                      <div>
+                        <h2 className="text-xl font-semibold" style={{ color: 'var(--accent-color)' }}>Request Time Off</h2>
+                        <p className="text-xs text-zinc-500 mt-0.5">3 fields. No approval maze. Just done.</p>
+                      </div>
+                      <button onClick={() => setShowLeaveModal(false)} className="text-zinc-400 hover:text-white text-2xl leading-none">×</button>
+                    </div>
+                    <div className="space-y-4">
+                      <div>
+                        <label className="block text-xs text-zinc-400 mb-1.5 uppercase tracking-wider">Leave Type</label>
+                        <select
+                          value={leaveType}
+                          onChange={e => setLeaveType(e.target.value)}
+                          className="glass-input w-full rounded-2xl px-4 py-3 text-sm border border-white/10 focus:border-white/30 outline-none bg-black/40"
+                        >
+                          <option>Vacation</option>
+                          <option>Sick Leave</option>
+                          <option>Personal</option>
+                          <option>Bereavement</option>
+                          <option>Parental</option>
+                          <option>Mental Health Day</option>
+                        </select>
+                      </div>
+                      <div className="grid grid-cols-2 gap-3">
+                        <div>
+                          <label className="block text-xs text-zinc-400 mb-1.5 uppercase tracking-wider">Start Date</label>
+                          <input
+                            type="date"
+                            value={leaveStart}
+                            onChange={e => setLeaveStart(e.target.value)}
+                            className="glass-input w-full rounded-2xl px-4 py-3 text-sm border border-white/10 focus:border-white/30 outline-none bg-black/40"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs text-zinc-400 mb-1.5 uppercase tracking-wider">End Date</label>
+                          <input
+                            type="date"
+                            value={leaveEnd}
+                            onChange={e => setLeaveEnd(e.target.value)}
+                            className="glass-input w-full rounded-2xl px-4 py-3 text-sm border border-white/10 focus:border-white/30 outline-none bg-black/40"
+                          />
+                        </div>
+                      </div>
+                      <div>
+                        <label className="block text-xs text-zinc-400 mb-1.5 uppercase tracking-wider">Note (optional)</label>
+                        <input
+                          type="text"
+                          value={leaveNote}
+                          onChange={e => setLeaveNote(e.target.value)}
+                          placeholder="e.g. Family trip, doctor appointment…"
+                          className="glass-input w-full rounded-2xl px-4 py-3 text-sm border border-white/10 focus:border-white/30 outline-none bg-black/40 placeholder:text-zinc-600"
+                        />
+                      </div>
+                      <button
+                        onClick={() => {
+                          if (!leaveStart || !leaveEnd) return
+                          const start = new Date(leaveStart)
+                          const end = new Date(leaveEnd)
+                          const days = Math.max(1, Math.round((end.getTime() - start.getTime()) / 86400000) + 1)
+                          setMyLeaveRequests(prev => [...prev, { type: leaveType, start: leaveStart, end: leaveEnd, days, status: 'Pending', note: leaveNote }])
+                          setLeaveStart('')
+                          setLeaveEnd('')
+                          setLeaveNote('')
+                          setShowLeaveModal(false)
+                          toast.success(`${leaveType} request submitted! Your manager will be notified.`)
+                        }}
+                        disabled={!leaveStart || !leaveEnd}
+                        className="w-full py-3.5 rounded-2xl font-semibold text-sm transition-all active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed"
+                        style={{ backgroundColor: 'var(--accent-color)', color: '#000' }}
+                      >
+                        Submit Request
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
+
               <div className="flex items-center justify-between">
                 <div>
                   <h1 className="text-2xl font-semibold neon-green">Leave Management</h1>
-                  <p className="text-sm text-zinc-400">Manage PTO requests and absence tracking</p>
+                  <p className="text-sm text-zinc-400">Your PTO balance, requests, and team coverage</p>
                 </div>
+                <button
+                  onClick={() => setShowLeaveModal(true)}
+                  className="px-5 py-2.5 rounded-xl text-sm font-semibold transition-all hover:opacity-90 active:scale-[0.97]"
+                  style={{ backgroundColor: 'var(--accent-color)', color: '#000' }}
+                >
+                  + Request Time Off
+                </button>
               </div>
+
+              {/* My PTO balance + stats */}
               <div className="grid grid-cols-4 gap-4">
-                {[['Pending Requests', '5'], ['Approved This Month', '12'], ['Denied This Month', '2'], ['Avg PTO Balance', '14.2 days']].map(([label, val]) => (
+                {[
+                  ['My PTO Balance', `${(80 - myLeaveRequests.filter(r => r.status === 'Approved').reduce((s, r) => s + r.days, 0)).toFixed(0)} days`],
+                  ['Pending Requests', `${myLeaveRequests.filter(r => r.status === 'Pending').length + 5}`],
+                  ['Approved This Month', '12'],
+                  ['Avg Team Balance', '14.2 days'],
+                ].map(([label, val]) => (
                   <div key={label} className="glass rounded-2xl p-4 text-center">
                     <div className="text-2xl font-bold" style={{ color: 'var(--accent-color)' }}>{val}</div>
                     <div className="text-xs text-zinc-400 mt-1">{label}</div>
                   </div>
                 ))}
               </div>
+
+              {/* My Requests */}
               <div className="glass rounded-3xl p-6">
-                <h2 className="text-lg font-semibold mb-4" style={{ color: 'var(--accent-color)' }}>Pending Leave Requests</h2>
+                <h2 className="text-lg font-semibold mb-4" style={{ color: 'var(--accent-color)' }}>My Requests</h2>
+                {myLeaveRequests.length === 0 ? (
+                  <div className="text-center py-8">
+                    <div className="text-zinc-500 mb-3">No requests yet.</div>
+                    <button
+                      onClick={() => setShowLeaveModal(true)}
+                      className="px-4 py-2 rounded-xl text-sm font-medium transition-all hover:opacity-90"
+                      style={{ backgroundColor: 'var(--accent-color)', color: '#000' }}
+                    >
+                      Request Time Off
+                    </button>
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    {myLeaveRequests.map((req, i) => (
+                      <div key={i} className="flex items-center justify-between bg-white/5 rounded-xl px-4 py-3">
+                        <div>
+                          <div className="font-medium text-sm">{req.type}</div>
+                          <div className="text-xs text-zinc-400">{req.start} – {req.end} · {req.days} day{req.days > 1 ? 's' : ''}{req.note ? ` · ${req.note}` : ''}</div>
+                        </div>
+                        <span className={`px-3 py-1 rounded-full text-xs font-medium ${req.status === 'Approved' ? 'bg-emerald-500/20 text-emerald-400' : req.status === 'Denied' ? 'bg-red-500/20 text-red-400' : 'bg-amber-500/20 text-amber-400'}`}>
+                          {req.status}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* Admin: Pending team requests */}
+              <div className="glass rounded-3xl p-6">
+                <h2 className="text-lg font-semibold mb-4" style={{ color: 'var(--accent-color)' }}>Team Pending Requests</h2>
                 <div className="space-y-3">
                   {[
-                    { name: 'Parker Kim', type: 'Vacation', dates: 'May 5–9, 2026', days: 5, status: 'Pending' },
-                    { name: 'Quinn Torres', type: 'Sick Leave', dates: 'Apr 24, 2026', days: 1, status: 'Pending' },
-                    { name: 'Skyler Reed', type: 'Personal', dates: 'May 12, 2026', days: 1, status: 'Pending' },
-                    { name: 'Avery Lane', type: 'Vacation', dates: 'May 19–23, 2026', days: 5, status: 'Pending' },
-                    { name: 'Dakota Lane', type: 'Bereavement', dates: 'Apr 25–27, 2026', days: 3, status: 'Pending' },
-                  ].map(({ name, type, dates, days, status }) => (
+                    { name: 'Parker Kim', type: 'Vacation', dates: 'May 5–9, 2026', days: 5 },
+                    { name: 'Quinn Torres', type: 'Sick Leave', dates: 'Apr 24, 2026', days: 1 },
+                    { name: 'Skyler Reed', type: 'Personal', dates: 'May 12, 2026', days: 1 },
+                    { name: 'Avery Lane', type: 'Vacation', dates: 'May 19–23, 2026', days: 5 },
+                    { name: 'Dakota Lane', type: 'Bereavement', dates: 'Apr 25–27, 2026', days: 3 },
+                  ].map(({ name, type, dates, days }) => (
                     <div key={name} className="flex items-center justify-between bg-white/5 rounded-xl px-4 py-3">
                       <div>
                         <div className="font-medium">{name}</div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -358,12 +358,13 @@ function TimesheetView({ user }: { user: any }) {
 
       {/* Timecards table (14-day period) */}
       <div className="glass rounded-3xl overflow-hidden">
-        <div className="px-6 py-3 border-b border-white/10 flex justify-between text-xs uppercase tracking-[1px] text-zinc-400">
+        <div className="overflow-x-auto">
+        <div className="px-6 py-3 border-b border-white/10 flex justify-between text-xs uppercase tracking-[1px] text-zinc-400" style={{ minWidth: '700px' }}>
           {dayNames.map((n, i) => (
             <div key={i} className="text-center">{n}</div>
           ))}
         </div>
-        <div className="px-6 py-4 flex justify-between gap-3">
+        <div className="px-6 py-4 flex justify-between gap-3" style={{ minWidth: '700px' }}>
           {dayDates.map((d, i) => {
             const key = entryKey(periodId, i)
             const val = entries[key] || ''
@@ -387,6 +388,7 @@ function TimesheetView({ user }: { user: any }) {
               </div>
             )
           })}
+        </div>
         </div>
       </div>
 
@@ -427,24 +429,12 @@ function TimesheetView({ user }: { user: any }) {
   )
 }
 
-// ===== Theme-aware Logo SVG =====
-function LogoSVG({ className, accentColor = 'var(--accent-color)' }: { className?: string; accentColor?: string }) {
+// ===== Logo SVG =====
+function LogoSVG({ className }: { className?: string }) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" fill="none" className={className}>
-      <circle cx="100" cy="100" r="90" fill="#000" stroke={accentColor} strokeWidth="3.5"/>
-      <rect x="97.5" y="18" width="5" height="14" rx="2.5" fill={accentColor} opacity="0.75"/>
-      <rect x="168" y="97.5" width="14" height="5" rx="2.5" fill={accentColor} opacity="0.75"/>
-      <rect x="97.5" y="168" width="5" height="14" rx="2.5" fill={accentColor} opacity="0.75"/>
-      <rect x="18" y="97.5" width="14" height="5" rx="2.5" fill={accentColor} opacity="0.75"/>
-      <line x1="100" y1="100" x2="58" y2="60" stroke={accentColor} strokeWidth="4" strokeLinecap="round" opacity="0.55"/>
-      <path d="M 117 28 L 80 108 L 105 108 L 88 172 L 138 88 L 111 88 Z" fill={accentColor}/>
-      <path d="M 117 44 L 88 108 L 107 108 L 93 153 L 130 94 L 109 94 Z" fill="#000" opacity="0.22"/>
-      <circle cx="100" cy="100" r="6" fill={accentColor}/>
-      <circle cx="100" cy="100" r="3" fill="#000"/>
-      <circle cx="42" cy="65" r="5" fill={accentColor} opacity="0.8"/>
-      <line x1="46" y1="68" x2="68" y2="82" stroke={accentColor} strokeWidth="1.8" strokeLinecap="round" opacity="0.45"/>
-      <circle cx="156" cy="148" r="5" fill={accentColor} opacity="0.8"/>
-      <line x1="152" y1="144" x2="132" y2="126" stroke={accentColor} strokeWidth="1.8" strokeLinecap="round" opacity="0.45"/>
+      <circle cx="100" cy="100" r="86" stroke="white" strokeWidth="2"/>
+      <path d="M 116 28 L 70 108 L 102 108 L 80 172 L 146 90 L 112 90 Z" fill="white"/>
     </svg>
   )
 }
@@ -520,7 +510,7 @@ function LoginPage() {
       <div className="hidden lg:flex w-5/12 flex-col justify-between p-10 relative z-10">
         <div>
           <div className="flex items-center gap-3 mb-10">
-            <LogoSVG className="h-9 w-auto" accentColor={loginAccentHex} />
+            <LogoSVG className="h-9 w-auto" />
             <span className="font-semibold text-2xl tracking-[1px]">SWIFTSHIFT</span>
           </div>
           <div className="max-w-[380px]">
@@ -705,7 +695,7 @@ function SignupPage() {
       <div className="hidden lg:flex w-5/12 flex-col justify-between p-10 relative z-10">
         <div>
           <div className="flex items-center gap-3 mb-10">
-            <LogoSVG className="h-9 w-auto" accentColor={signupAccentHex} />
+            <LogoSVG className="h-9 w-auto" />
             <span className="font-semibold text-2xl tracking-[1px]">SWIFTSHIFT</span>
           </div>
           <div className="max-w-[380px]">
@@ -910,6 +900,7 @@ export default function App() {
   const [taxFormData, setTaxFormData] = useState<any | null>(null)
   const [taxLoading, setTaxLoading] = useState(false)
   const [selectedDoc, setSelectedDoc] = useState<{ label: string; content: string } | null>(null)
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
 
   // Leave request state (anti-Workday: 3-field form instead of 9-step flow)
   const [showLeaveModal, setShowLeaveModal] = useState(false)
@@ -918,6 +909,11 @@ export default function App() {
   const [leaveEnd, setLeaveEnd] = useState('')
   const [leaveNote, setLeaveNote] = useState('')
   const [myLeaveRequests, setMyLeaveRequests] = useState<Array<{ type: string; start: string; end: string; days: number; status: string; note: string }>>([])
+
+  const navTo = (view: View) => {
+    setActiveView(view)
+    setMobileMenuOpen(false)
+  }
 
   const orgData = {
     id: 'ceo',
@@ -1031,8 +1027,7 @@ export default function App() {
 
   // Update favicon dynamically when theme changes
   useEffect(() => {
-    const accent = getThemeAccentHex(theme)
-    const svgContent = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none"><rect width="64" height="64" rx="14" fill="#000"/><circle cx="32" cy="32" r="26" stroke="${accent}" stroke-width="2.5" fill="none"/><rect x="30.5" y="9" width="3" height="6" rx="1.5" fill="${accent}" opacity="0.75"/><rect x="49" y="30.5" width="6" height="3" rx="1.5" fill="${accent}" opacity="0.75"/><rect x="30.5" y="49" width="3" height="6" rx="1.5" fill="${accent}" opacity="0.75"/><rect x="9" y="30.5" width="6" height="3" rx="1.5" fill="${accent}" opacity="0.75"/><path d="M 37 8 L 22 34 L 32 34 L 26 56 L 46 30 L 35 30 Z" fill="${accent}"/></svg>`
+    const svgContent = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none"><rect width="64" height="64" rx="14" fill="#0a0a0a"/><circle cx="32" cy="32" r="27" stroke="white" stroke-width="1.5"/><path d="M 37 9 L 22 35 L 33 35 L 26 55 L 47 29 L 35 29 Z" fill="white"/></svg>`
     const url = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgContent)}`
     let link = document.querySelector<HTMLLinkElement>("link[rel~='icon']")
     if (!link) {
@@ -1041,7 +1036,7 @@ export default function App() {
       document.head.appendChild(link)
     }
     link.href = url
-  }, [theme])
+  }, [])
 
   const cycleTheme = () => {
     setTheme(t => t === 'green' ? 'white' : t === 'white' ? 'orange' : t === 'orange' ? 'cyan' : t === 'cyan' ? 'pink' : t === 'pink' ? 'purple' : 'green')
@@ -1374,23 +1369,35 @@ export default function App() {
   return (
     <div className="ta-app" data-theme={theme}>
       <nav className="ta-navbar">
-        <div className="ta-navbar-brand cursor-pointer" onClick={() => setActiveView('clock')}>
-          <LogoSVG className="h-10 w-auto" />
-          <span>SwiftShift</span>
+        <div className="flex items-center gap-2">
+          {/* Hamburger (mobile only) */}
+          <button
+            className="ta-hamburger"
+            onClick={() => setMobileMenuOpen(o => !o)}
+            aria-label="Toggle menu"
+          >
+            <span />
+            <span />
+            <span />
+          </button>
+          <div className="ta-navbar-brand cursor-pointer" onClick={() => navTo('clock')}>
+            <LogoSVG className="h-10 w-auto" />
+            <span>SwiftShift</span>
+          </div>
         </div>
         <div className="ta-navbar-user">
           {/* Daily streak counter */}
           <div className="flex items-center gap-1.5 px-3 py-1 text-sm text-white/60 border border-white/10 rounded-full">
             <span style={{ color: 'var(--accent-color)' }}>{streak > 0 ? '🔥' : '○'}</span>
             <span className="font-semibold" style={{ color: 'var(--accent-color)' }}>{streak}</span>
-            <span className="text-white/40">day streak</span>
+            <span className="text-white/40 ta-streak-label">day streak</span>
           </div>
           {/* User menu dropdown */}
           <div className="relative group">
             <span className="text-sm text-zinc-400 cursor-pointer">Hi, {user.first_name} ▾</span>
             <div className="absolute right-0 top-full w-48 bg-zinc-900 border border-white/10 rounded-xl shadow-lg hidden group-hover:block z-50 pt-1">
               <button
-                onClick={() => setActiveView('profile')}
+                onClick={() => navTo('profile')}
                 className="w-full text-left px-4 py-2 text-sm hover:bg-white/5 rounded-t-xl"
               >
                 Profile
@@ -1422,11 +1429,17 @@ export default function App() {
         </div>
       </nav>
 
-      <aside className="ta-sidebar">
+      {/* Mobile sidebar backdrop */}
+      <div
+        className={`ta-sidebar-backdrop ${mobileMenuOpen ? 'mobile-open' : ''}`}
+        onClick={() => setMobileMenuOpen(false)}
+      />
+
+      <aside className={`ta-sidebar ${mobileMenuOpen ? 'mobile-open' : ''}`}>
         <nav className="ta-nav">
           <button
             className={`ta-nav-btn ${activeView === 'clock' ? 'active' : ''}`}
-            onClick={() => setActiveView('clock')}
+            onClick={() => navTo('clock')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
@@ -1435,7 +1448,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'timesheet' ? 'active' : ''}`}
-            onClick={() => setActiveView('timesheet')}
+            onClick={() => navTo('timesheet')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/>
@@ -1444,7 +1457,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'rewards' ? 'active' : ''}`}
-            onClick={() => setActiveView('rewards')}
+            onClick={() => navTo('rewards')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/>
@@ -1453,7 +1466,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'insurance' ? 'active' : ''}`}
-            onClick={() => setActiveView('insurance')}
+            onClick={() => navTo('insurance')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
@@ -1462,7 +1475,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'orgchart' ? 'active' : ''}`}
-            onClick={() => setActiveView('orgchart')}
+            onClick={() => navTo('orgchart')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <rect x="8" y="2" width="8" height="4" rx="1"/><rect x="2" y="14" width="8" height="4" rx="1"/><rect x="14" y="14" width="8" height="4" rx="1"/><line x1="12" y1="6" x2="12" y2="11"/><line x1="6" y1="14" x2="6" y2="11"/><line x1="18" y1="14" x2="18" y2="11"/><line x1="6" y1="11" x2="18" y2="11"/>
@@ -1471,7 +1484,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'taxes' ? 'active' : ''}`}
-            onClick={() => setActiveView('taxes')}
+            onClick={() => navTo('taxes')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <path d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"/>
@@ -1480,7 +1493,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn mb-2 ${activeView === 'groktax' ? 'active' : ''}`}
-            onClick={() => setActiveView('groktax')}
+            onClick={() => navTo('groktax')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6"/>
@@ -1490,7 +1503,7 @@ export default function App() {
           <div className="ta-nav-section">Job Applications</div>
           <button
             className={`ta-nav-btn mb-2 ${activeView === 'applications' ? 'active' : ''}`}
-            onClick={() => setActiveView('applications')}
+            onClick={() => navTo('applications')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
@@ -1500,7 +1513,7 @@ export default function App() {
           <div className="ta-nav-section">Admin</div>
           <button
             className={`ta-nav-btn ${activeView === 'admin' ? 'active' : ''}`}
-            onClick={() => setActiveView('admin')}
+            onClick={() => navTo('admin')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/>
@@ -1509,7 +1522,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'schedules' ? 'active' : ''}`}
-            onClick={() => setActiveView('schedules')}
+            onClick={() => navTo('schedules')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/>
@@ -1518,7 +1531,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'payroll' ? 'active' : ''}`}
-            onClick={() => setActiveView('payroll')}
+            onClick={() => navTo('payroll')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <rect x="2" y="5" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/>
@@ -1527,7 +1540,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'reports' ? 'active' : ''}`}
-            onClick={() => setActiveView('reports')}
+            onClick={() => navTo('reports')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/>
@@ -1536,7 +1549,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'leaves' ? 'active' : ''}`}
-            onClick={() => setActiveView('leaves')}
+            onClick={() => navTo('leaves')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/>
@@ -1545,7 +1558,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'compliance' ? 'active' : ''}`}
-            onClick={() => setActiveView('compliance')}
+            onClick={() => navTo('compliance')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/>
@@ -1554,7 +1567,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'hiring' ? 'active' : ''}`}
-            onClick={() => setActiveView('hiring')}
+            onClick={() => navTo('hiring')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <path d="M16 21v-2a4 4 0 00-4-4H6a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><line x1="19" y1="8" x2="19" y2="14"/><line x1="22" y1="11" x2="16" y2="11"/>
@@ -1565,7 +1578,7 @@ export default function App() {
         <div className="mt-auto pt-4">
           <button
             className={`ta-nav-btn ${activeView === 'grokky' ? 'active' : ''}`}
-            onClick={() => setActiveView('grokky')}
+            onClick={() => navTo('grokky')}
             style={{ color: 'var(--accent-color)', textShadow: '0 0 8px var(--accent-color)' }}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
@@ -1580,12 +1593,12 @@ export default function App() {
         <main className="ta-main">
           {activeView === 'clock' && (
             <>
-              <div className="flex gap-6 items-stretch max-w-[1200px] mx-auto">
+              <div className="flex flex-col xl:flex-row gap-6 items-stretch max-w-[1200px] mx-auto">
               {/* Left: Dashboard */}
               <div className="flex-1 space-y-6">
                 {/* Dashboard card */}
-                <div className="glass rounded-3xl p-8">
-                  <div className="flex items-start gap-10">
+                <div className="glass rounded-3xl p-5 sm:p-8">
+                  <div className="flex flex-col sm:flex-row items-start gap-6 sm:gap-10">
                     {/* Left: Greeting, Time, Status, Buttons */}
                     <div className="flex-1">
                       <div className="text-sm text-zinc-400 mb-1">{longDate(now)}</div>
@@ -1593,7 +1606,7 @@ export default function App() {
                         {greeting(now.getHours())}, {user.first_name}
                       </div>
 
-                      <div className="font-mono text-6xl tabular-nums tracking-[2px] mb-6">
+                      <div className="font-mono text-4xl sm:text-6xl tabular-nums tracking-[2px] mb-6">
                         {now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
                       </div>
 
@@ -1711,7 +1724,7 @@ export default function App() {
                     </div>
                   </div>
 
-                  <div className="mt-6 grid grid-cols-3 gap-4 text-sm">
+                  <div className="mt-6 grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
                     <div className="glass rounded-2xl p-4">
                       <div className="text-zinc-400 mb-1">Session</div>
                       <div className="font-mono text-xl neon-green">{formatMs(sessionWorkedMs)}</div>
@@ -1731,7 +1744,7 @@ export default function App() {
                 <div className="glass rounded-3xl p-6">
                   <div className="flex items-center justify-between mb-4">
                     <div className="text-sm uppercase tracking-[2px] text-white">My Schedule This Week</div>
-                    <button onClick={() => setActiveView('schedules')} className="text-xs text-zinc-500 hover:text-white underline underline-offset-2">Full schedule →</button>
+                    <button onClick={() => navTo('schedules')} className="text-xs text-zinc-500 hover:text-white underline underline-offset-2">Full schedule →</button>
                   </div>
                   <div className="grid grid-cols-7 gap-2">
                     {(['Mon','Tue','Wed','Thu','Fri','Sat','Sun']).map((day, i) => {
@@ -1754,13 +1767,13 @@ export default function App() {
               </div>
 
               {/* Right sidebar: This pay period + Real Time Rewards */}
-              <aside className="w-80 shrink-0 flex flex-col gap-4">
+              <aside className="xl:w-80 shrink-0 flex flex-col sm:flex-row xl:flex-col gap-4">
                 <div className="glass rounded-3xl p-8 flex-1">
                   <div className="text-sm uppercase tracking-[2px] text-white mb-3">This pay period</div>
                   <div className="text-lg font-medium mb-2 neon-green">{periodLabel}</div>
                   <div className="text-sm text-zinc-400 mb-4">Regular hours: <span className="font-mono neon-green">{periodHours}</span> hrs</div>
                   <button
-                    onClick={() => setActiveView('timesheet')}
+                    onClick={() => navTo('timesheet')}
                     className="text-sm underline decoration-white/30 hover:decoration-white"
                   >
                     See my time →
@@ -1783,7 +1796,7 @@ export default function App() {
                     </div>
                   </div>
                   <button
-                    onClick={() => setActiveView('rewards')}
+                    onClick={() => navTo('rewards')}
                     className="text-sm underline decoration-white/30 hover:decoration-white"
                   >
                     See rewards →
@@ -1799,7 +1812,7 @@ export default function App() {
                   </div>
                   <div className="text-xs text-zinc-500 mb-3">Accruing at 1 hr per 30 worked</div>
                   <button
-                    onClick={() => { setActiveView('leaves'); setShowLeaveModal(true) }}
+                    onClick={() => { navTo('leaves'); setShowLeaveModal(true) }}
                     className="text-sm px-3 py-1.5 rounded-xl font-medium w-full text-center transition-all hover:opacity-80"
                     style={{ backgroundColor: 'var(--accent-color)', color: '#000' }}
                   >
@@ -1845,7 +1858,7 @@ export default function App() {
           {activeView === 'admin' && (
             <div className="max-w-5xl mx-auto">
               <div className="glass rounded-3xl p-8">
-                <div className="flex items-center justify-between mb-6">
+                <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
                   <h1 className="text-2xl font-semibold neon-green">Admin: Manage Users</h1>
                   <button
                     onClick={() => {
@@ -1862,7 +1875,8 @@ export default function App() {
                     Save Changes
                   </button>
                 </div>
-                <table className="w-full text-xs">
+                <div className="overflow-x-auto">
+                <table className="w-full text-xs" style={{ minWidth: '700px' }}>
                   <thead>
                     <tr className="text-zinc-400 border-b border-white/10">
                       <th className="text-left py-1">First Name</th>
@@ -1965,13 +1979,14 @@ export default function App() {
                     ))}
                   </tbody>
                 </table>
+                </div>
                 {users.length === 0 && <div className="text-zinc-400 mt-4">No users yet.</div>}
               </div>
             </div>
           )}
           {activeView === 'schedules' && (
             <div className="max-w-5xl mx-auto space-y-6">
-              <div className="flex items-center justify-between">
+              <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <h1 className="text-2xl font-semibold neon-green">Schedule Management</h1>
                   <p className="text-sm text-zinc-400">Manage shifts and employee schedules</p>
@@ -1980,7 +1995,7 @@ export default function App() {
                   + Add Shift
                 </button>
               </div>
-              <div className="grid grid-cols-7 gap-2">
+              <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-2">
                 {['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'].map(day => (
                   <div key={day} className="glass rounded-2xl p-3">
                     <div className="text-xs font-semibold text-zinc-400 mb-2 uppercase">{day}</div>
@@ -1997,7 +2012,7 @@ export default function App() {
               </div>
               <div className="glass rounded-3xl p-6">
                 <h2 className="text-lg font-semibold mb-4" style={{ color: 'var(--accent-color)' }}>Shift Coverage Summary</h2>
-                <div className="grid grid-cols-3 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                   {[['Total Shifts This Week', '14'], ['Filled Shifts', '11'], ['Open Shifts', '3']].map(([label, val]) => (
                     <div key={label} className="bg-white/5 rounded-2xl p-4 text-center">
                       <div className="text-2xl font-bold" style={{ color: 'var(--accent-color)' }}>{val}</div>
@@ -2010,7 +2025,7 @@ export default function App() {
           )}
           {activeView === 'payroll' && (
             <div className="max-w-5xl mx-auto space-y-6">
-              <div className="flex items-center justify-between">
+              <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <h1 className="text-2xl font-semibold neon-green">Payroll</h1>
                   <p className="text-sm text-zinc-400">Current pay period: Apr 15 – Apr 30, 2026</p>
@@ -2019,7 +2034,7 @@ export default function App() {
                   Run Payroll
                 </button>
               </div>
-              <div className="grid grid-cols-4 gap-4">
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
                 {[['Total Payroll', '$48,320'], ['Employees Paid', '24'], ['Avg Hours/Employee', '38.5h'], ['Overtime Hours', '42h']].map(([label, val]) => (
                   <div key={label} className="glass rounded-2xl p-4 text-center">
                     <div className="text-2xl font-bold" style={{ color: 'var(--accent-color)' }}>{val}</div>
@@ -2029,7 +2044,8 @@ export default function App() {
               </div>
               <div className="glass rounded-3xl p-6">
                 <h2 className="text-lg font-semibold mb-4" style={{ color: 'var(--accent-color)' }}>Employee Payroll Summary</h2>
-                <table className="w-full text-sm">
+                <div className="overflow-x-auto">
+                <table className="w-full text-sm" style={{ minWidth: '500px' }}>
                   <thead>
                     <tr className="text-zinc-400 border-b border-white/10 text-left">
                       <th className="py-2">Employee</th>
@@ -2060,6 +2076,7 @@ export default function App() {
                     ))}
                   </tbody>
                 </table>
+                </div>
               </div>
             </div>
           )}
@@ -2069,7 +2086,7 @@ export default function App() {
                 <h1 className="text-2xl font-semibold neon-green">Reports &amp; Analytics</h1>
                 <p className="text-sm text-zinc-400">Workforce performance and operational insights</p>
               </div>
-              <div className="grid grid-cols-2 gap-6">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
                 {[
                   { title: 'Hours Worked (This Month)', value: '1,842h', change: '+4.2%', sub: 'vs last month' },
                   { title: 'Labor Cost (This Month)', value: '$94,600', change: '+1.8%', sub: 'vs last month' },
@@ -2199,7 +2216,7 @@ export default function App() {
               </div>
 
               {/* My PTO balance + stats */}
-              <div className="grid grid-cols-4 gap-4">
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
                 {[
                   ['My PTO Balance', `${(80 - myLeaveRequests.filter(r => r.status === 'Approved').reduce((s, r) => s + r.days, 0)).toFixed(0)} days`],
                   ['Pending Requests', `${myLeaveRequests.filter(r => r.status === 'Pending').length + 5}`],
@@ -2276,7 +2293,7 @@ export default function App() {
                 <h1 className="text-2xl font-semibold neon-green">Compliance &amp; Audit</h1>
                 <p className="text-sm text-zinc-400">Policy compliance, certifications, and audit logs</p>
               </div>
-              <div className="grid grid-cols-3 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                 {[['Compliance Score', '94%'], ['Open Incidents', '2'], ['Overdue Trainings', '7']].map(([label, val]) => (
                   <div key={label} className="glass rounded-2xl p-4 text-center">
                     <div className="text-3xl font-bold" style={{ color: 'var(--accent-color)' }}>{val}</div>
@@ -2327,7 +2344,7 @@ export default function App() {
           )}
           {activeView === 'hiring' && (
             <div className="max-w-5xl mx-auto space-y-6">
-              <div className="flex items-center justify-between">
+              <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <h1 className="text-2xl font-semibold neon-green">Hiring &amp; Onboarding</h1>
                   <p className="text-sm text-zinc-400">Recruitment pipeline and new hire management</p>
@@ -2336,7 +2353,7 @@ export default function App() {
                   + Post Job
                 </button>
               </div>
-              <div className="grid grid-cols-4 gap-4">
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
                 {[['Open Positions', '6'], ['Active Applicants', '38'], ['Interviews This Week', '9'], ['Offers Pending', '3']].map(([label, val]) => (
                   <div key={label} className="glass rounded-2xl p-4 text-center">
                     <div className="text-2xl font-bold" style={{ color: 'var(--accent-color)' }}>{val}</div>
@@ -2344,7 +2361,7 @@ export default function App() {
                   </div>
                 ))}
               </div>
-              <div className="grid grid-cols-2 gap-6">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
                 <div className="glass rounded-3xl p-6">
                   <h2 className="text-lg font-semibold mb-4" style={{ color: 'var(--accent-color)' }}>Hiring Pipeline</h2>
                   <div className="space-y-3">
@@ -2543,21 +2560,21 @@ export default function App() {
           {activeView === 'orgchart' && (
             <div className="flex-1 flex flex-col">
               {/* Header bar */}
-              <div className="flex items-center justify-between px-6 py-4 border-b border-white/10">
+              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 px-4 sm:px-6 py-4 border-b border-white/10">
                 <div>
-                  <p className="text-xs text-zinc-400">Hover for details • Click ▶ to expand</p>
+                  <p className="text-xs text-zinc-400">Tap/hover for details • Tap ▶ to expand</p>
                 </div>
                 <div className="flex items-center gap-3">
                   <input
                     type="text"
                     placeholder="Search..."
-                    className="bg-white/5 rounded-xl px-3 py-1.5 text-sm focus:bg-white/10 focus:outline-none w-56"
+                    className="bg-white/5 rounded-xl px-3 py-1.5 text-sm focus:bg-white/10 focus:outline-none flex-1 sm:w-56"
                     value={orgSearch}
                     onChange={(e) => setOrgSearch(e.target.value)}
                   />
                   <button
                     onClick={() => setOrgExpandedAll(!orgExpandedAll)}
-                    className="text-xs px-3 py-1.5 rounded-lg bg-white/10 hover:bg-white/20 transition-colors"
+                    className="text-xs px-3 py-1.5 rounded-lg bg-white/10 hover:bg-white/20 transition-colors whitespace-nowrap"
                   >
                     {orgExpandedAll ? 'Collapse All' : 'Expand All'}
                   </button>
@@ -2914,7 +2931,7 @@ export default function App() {
               </div>
 
               {/* Resume Upload */}
-              <div className="glass rounded-3xl p-6 flex items-center justify-between">
+              <div className="glass rounded-3xl p-6 flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <div className="font-medium">Your Resume</div>
                   <div className="text-sm text-zinc-500">Upload once, apply everywhere</div>


### PR DESCRIPTION
Removes Workday friction and annoyances from SwiftShift.

## Changes
- Request Time Off modal: 3 fields vs Workday's 9-step flow
- PTO balance card visible directly on clock dashboard
- Next Payday countdown with progress bar
- My Schedule week-at-a-glance widget on home screen
- Spacebar shortcut for clock in/out
- My Requests section in Leave Management with status badges
- Anti-Workday value props on login and signup pages

Closes #25

Generated with [Claude Code](https://claude.ai/code)