### PR TITLE
feat: add guided tour for new users

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,8 @@ import { toast } from 'sonner'
 import { useTimesheet } from './hooks/useTimesheet'
 import { Rewards } from './components/Rewards'
 import { LootDrop } from './components/LootDrop'
+import { Tour } from './components/Tour'
+import { FeaturePreview } from './components/FeaturePreview'
 
 const API_BASE = (() => {
   const m = window.location.pathname.match(/^(\/hackathon\/preview\/[^/]+)/)
@@ -467,6 +469,7 @@ function LoginPage() {
   const [showPassword, setShowPassword] = useState(false)
   const [focusedField, setFocusedField] = useState<string | null>(null)
   const [shockwaveActive] = useState(false)
+  const [showFeaturePreview, setShowFeaturePreview] = useState(false)
 
   const isReturningUser = !!localStorage.getItem('lastEmail')
   const loginAccentHex = getThemeAccentHex(localStorage.getItem('theme') || 'green')
@@ -635,6 +638,17 @@ function LoginPage() {
               <a href="#" className="text-zinc-500 hover:text-white transition-colors">Forgot password?</a>
               <a href="signup" className="text-zinc-400 hover:text-white underline underline-offset-4">Create account</a>
             </div>
+
+            {/* Tour button */}
+            <div className="text-center mt-1">
+              <button
+                type="button"
+                onClick={() => setShowFeaturePreview(true)}
+                className="text-xs text-zinc-600 hover:text-zinc-400 transition-colors"
+              >
+                Explore features →
+              </button>
+            </div>
           </form>
 
           {/* Footer hint */}
@@ -648,6 +662,13 @@ function LoginPage() {
       <div className="absolute bottom-6 right-0 p-4 text-[10px] text-zinc-600">
         © 2026 SwiftShift. All rights reserved.
       </div>
+
+      {showFeaturePreview && (
+        <FeaturePreview
+          onClose={() => setShowFeaturePreview(false)}
+          accentHex={loginAccentHex}
+        />
+      )}
     </div>
   )
 }
@@ -662,6 +683,7 @@ function SignupPage() {
   const [showPassword, setShowPassword] = useState(false)
   const [focusedField, setFocusedField] = useState<string | null>(null)
   const [shockwaveActive] = useState(false)
+  const [showFeaturePreview, setShowFeaturePreview] = useState(false)
   const signupAccentHex = getThemeAccentHex(localStorage.getItem('theme') || 'green')
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -679,6 +701,7 @@ function SignupPage() {
       } else {
         localStorage.setItem('user', JSON.stringify(data))
         localStorage.setItem('lastEmail', email)
+        localStorage.setItem('swiftshift-tour-pending', '1')
         window.location.href = '.'
       }
     } catch {
@@ -843,6 +866,17 @@ function SignupPage() {
             <div className="text-center text-sm pt-1">
               <a href="login" className="text-zinc-400 hover:text-white underline underline-offset-4">Already have an account?</a>
             </div>
+
+            {/* Tour button */}
+            <div className="text-center mt-1">
+              <button
+                type="button"
+                onClick={() => setShowFeaturePreview(true)}
+                className="text-xs text-zinc-600 hover:text-zinc-400 transition-colors"
+              >
+                Explore features →
+              </button>
+            </div>
           </form>
 
           <div className="mt-6 pt-5 border-t border-white/10 text-center text-[10px] text-zinc-500 tracking-[1px]">
@@ -855,6 +889,13 @@ function SignupPage() {
       <div className="absolute bottom-6 right-0 p-4 text-[10px] text-zinc-600">
         © 2026 SwiftShift. All rights reserved.
       </div>
+
+      {showFeaturePreview && (
+        <FeaturePreview
+          onClose={() => setShowFeaturePreview(false)}
+          accentHex={signupAccentHex}
+        />
+      )}
     </div>
   )
 }
@@ -889,6 +930,7 @@ export default function App() {
 
   // Main app
   const [activeView, setActiveView] = useState<View>('clock')
+  const [showTour, setShowTour] = useState(() => localStorage.getItem('swiftshift-tour-pending') === '1')
   const [chatMessage, setChatMessage] = useState('')
   const [chatLoading, setChatLoading] = useState(false)
   const [chatHistory, setChatHistory] = useState<Array<{ role: 'user' | 'assistant'; content: string }>>([])
@@ -1003,6 +1045,13 @@ export default function App() {
   }
 
   useTimesheet() // runs side effects (seeding)
+
+  // Clear tour-pending flag and mark as seen once tour is displayed
+  useEffect(() => {
+    if (showTour) {
+      localStorage.removeItem('swiftshift-tour-pending')
+    }
+  }, [showTour])
 
   // Handle /admin URL
   useEffect(() => {
@@ -1367,6 +1416,12 @@ export default function App() {
                 className="w-full text-left px-4 py-2 text-sm hover:bg-white/5 rounded-t-xl"
               >
                 Profile
+              </button>
+              <button
+                onClick={() => setShowTour(true)}
+                className="w-full text-left px-4 py-2 text-sm hover:bg-white/5"
+              >
+                Take tour
               </button>
               <button
                 className="w-full text-left px-4 py-2 text-sm hover:bg-white/5 text-zinc-400 cursor-not-allowed"
@@ -2874,6 +2929,17 @@ export default function App() {
             </div>
           )}
         </main>
+
+        {/* Guided tour modal */}
+        {showTour && (
+          <Tour
+            onClose={() => {
+              setShowTour(false)
+              localStorage.setItem('swiftshift-tour-seen', '1')
+            }}
+            accentHex={themeAccentHex}
+          />
+        )}
 
         {/* Clock-out Loot Drop modal */}
         <LootDrop

--- a/frontend/src/components/FeaturePreview.tsx
+++ b/frontend/src/components/FeaturePreview.tsx
@@ -1,0 +1,82 @@
+import { motion } from 'framer-motion'
+
+const FEATURES = [
+  { icon: '⏱', title: 'Time Clock', desc: 'Clock in/out with one click. Real-time earnings display and break tracking.' },
+  { icon: '📋', title: 'Timesheet', desc: 'View, edit, and submit all your time entries. Track hours by project and task.' },
+  { icon: '🏆', title: 'Rewards', desc: 'Gamified daily streaks and real-time earnings Odometer for every second worked.' },
+  { icon: '💳', title: 'Payroll & Reports', desc: 'Full pay details, analytics dashboards, and exportable reports.' },
+  { icon: '💰', title: 'AI Tax Filing', desc: 'Upload your W-2 or 1099 and Swifty AI fills out your 1040 instantly.' },
+  { icon: '🤖', title: 'AI Assistant', desc: 'Chat with Swifty for instant HR answers, leave policy info, and more.' },
+  { icon: '⚡', title: 'InstaApply', desc: 'Upload your resume once — get matched to jobs and apply in seconds.' },
+  { icon: '🛡', title: 'Insurance & Benefits', desc: 'Browse and manage your health, dental, and vision benefits.' },
+  { icon: '📊', title: 'Org Chart', desc: 'Visualize your entire company structure at a glance.' },
+]
+
+interface FeaturePreviewProps {
+  onClose: () => void
+  accentHex?: string
+}
+
+export function FeaturePreview({ onClose, accentHex = '#D7FE51' }: FeaturePreviewProps) {
+  return (
+    <div
+      className="fixed inset-0 z-[300] flex items-center justify-center bg-black/80 backdrop-blur-sm p-4"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95, y: 20 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.95, y: 10 }}
+        transition={{ duration: 0.25 }}
+        className="glass w-full max-w-[560px] rounded-3xl border border-white/10 overflow-hidden"
+        style={{ boxShadow: `0 0 60px -20px ${accentHex}25, 0 28px 72px -14px rgba(0,0,0,0.85)` }}
+      >
+        {/* Header */}
+        <div className="px-8 pt-8 pb-4">
+          <div className="flex items-center justify-between mb-2">
+            <div className="text-xs tracking-[3px] uppercase" style={{ color: accentHex }}>
+              Product Tour
+            </div>
+            <button
+              onClick={onClose}
+              className="text-zinc-500 hover:text-white transition-colors text-2xl leading-none w-7 h-7 flex items-center justify-center rounded-lg hover:bg-white/5"
+              aria-label="Close feature preview"
+            >
+              ×
+            </button>
+          </div>
+          <h2 className="text-2xl font-semibold tracking-tight mb-1">Everything you need.</h2>
+          <p className="text-zinc-500 text-sm">SwiftShift is your all-in-one AI-powered HR platform.</p>
+        </div>
+
+        {/* Feature grid */}
+        <div className="px-8 pb-6 max-h-[50vh] overflow-y-auto">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
+            {FEATURES.map((f) => (
+              <div
+                key={f.title}
+                className="rounded-2xl border border-white/8 p-4 hover:border-white/15 transition-colors"
+                style={{ background: 'rgba(255,255,255,0.025)' }}
+              >
+                <div className="text-2xl mb-2 leading-none">{f.icon}</div>
+                <div className="font-semibold text-sm mb-1 text-white">{f.title}</div>
+                <div className="text-xs text-zinc-500 leading-relaxed">{f.desc}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="px-8 pb-8 pt-2 border-t border-white/8">
+          <button
+            onClick={onClose}
+            className="w-full py-2.5 rounded-xl text-sm font-semibold transition-all hover:opacity-90 active:scale-[0.98]"
+            style={{ background: accentHex, color: accentHex === '#D7FE51' || accentHex === '#E5E7EB' || accentHex === '#51FEFE' || accentHex === '#FE51D7' ? '#000' : '#fff' }}
+          >
+            Got it — let's go
+          </button>
+        </div>
+      </motion.div>
+    </div>
+  )
+}

--- a/frontend/src/components/Tour.tsx
+++ b/frontend/src/components/Tour.tsx
@@ -1,0 +1,174 @@
+import { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+
+interface TourStep {
+  icon: string
+  title: string
+  desc: string
+}
+
+const TOUR_STEPS: TourStep[] = [
+  {
+    icon: '👋',
+    title: 'Welcome to SwiftShift!',
+    desc: "You're in. Let's take a 60-second tour of the key features so you can hit the ground running.",
+  },
+  {
+    icon: '⏱',
+    title: 'Time Clock',
+    desc: 'Clock in and out with one click. Your earnings update in real time — every second counts. Track breaks too.',
+  },
+  {
+    icon: '📋',
+    title: 'Timesheet',
+    desc: 'All your time entries in one place. Add, edit, and submit your weekly timesheet with ease.',
+  },
+  {
+    icon: '🏆',
+    title: 'Rewards',
+    desc: 'Stay consistent and earn streak rewards. Watch your real-time earnings climb on the Odometer.',
+  },
+  {
+    icon: '💳',
+    title: 'Payroll & Reports',
+    desc: 'View pay details, export reports, and track your analytics — all in one dashboard.',
+  },
+  {
+    icon: '💰',
+    title: 'AI Tax Filing — Swifty',
+    desc: 'Upload your W-2 or 1099 and Swifty fills out your Form 1040 instantly. No accountant needed.',
+  },
+  {
+    icon: '🤖',
+    title: 'AI Assistant — Swifty',
+    desc: 'Ask Swifty anything — leave policies, HR questions, company info. Instant, intelligent answers.',
+  },
+  {
+    icon: '⚡',
+    title: 'InstaApply',
+    desc: 'Upload your resume once. SwiftShift matches you to jobs and applies in seconds.',
+  },
+  {
+    icon: '✅',
+    title: "You're all set!",
+    desc: "That covers the highlights. Start by clocking in — your first session is just one click away.",
+  },
+]
+
+interface TourProps {
+  onClose: () => void
+  accentHex?: string
+}
+
+export function Tour({ onClose, accentHex = '#D7FE51' }: TourProps) {
+  const [step, setStep] = useState(0)
+  const current = TOUR_STEPS[step]
+  const isLast = step === TOUR_STEPS.length - 1
+  const isDark = accentHex === '#D7FE51' || accentHex === '#E5E7EB' || accentHex === '#51FEFE' || accentHex === '#FE51D7'
+
+  const next = () => {
+    if (isLast) onClose()
+    else setStep(s => s + 1)
+  }
+
+  const prev = () => {
+    if (step > 0) setStep(s => s - 1)
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[300] flex items-center justify-center bg-black/75 backdrop-blur-sm"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={step}
+          initial={{ opacity: 0, y: 20, scale: 0.97 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: -10, scale: 0.97 }}
+          transition={{ duration: 0.22, ease: 'easeOut' }}
+          className="glass w-full max-w-[420px] rounded-3xl p-8 border border-white/10 mx-4"
+          style={{ boxShadow: `0 0 80px -20px ${accentHex}35, 0 28px 72px -14px rgba(0,0,0,0.85)` }}
+        >
+          {/* Progress bar */}
+          <div className="h-1 rounded-full bg-white/10 mb-6 overflow-hidden">
+            <motion.div
+              className="h-full rounded-full"
+              style={{ backgroundColor: accentHex }}
+              animate={{ width: `${((step + 1) / TOUR_STEPS.length) * 100}%` }}
+              transition={{ duration: 0.35 }}
+            />
+          </div>
+
+          {/* Step counter */}
+          <div className="text-xs tracking-[2px] text-zinc-500 mb-5 uppercase">
+            Step {step + 1} <span className="text-zinc-700">/ {TOUR_STEPS.length}</span>
+          </div>
+
+          {/* Icon */}
+          <div className="text-5xl mb-4 leading-none">{current.icon}</div>
+
+          {/* Title */}
+          <h2
+            className="text-2xl font-semibold tracking-tight mb-3"
+            style={{ color: step === 0 || isLast ? accentHex : 'white' }}
+          >
+            {current.title}
+          </h2>
+
+          {/* Description */}
+          <p className="text-zinc-400 text-sm leading-relaxed mb-8">
+            {current.desc}
+          </p>
+
+          {/* Actions */}
+          <div className="flex items-center justify-between gap-3">
+            <button
+              onClick={onClose}
+              className="text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
+            >
+              Skip tour
+            </button>
+            <div className="flex items-center gap-2">
+              {step > 0 && (
+                <button
+                  onClick={prev}
+                  className="px-4 py-2 rounded-xl border border-white/10 text-sm text-zinc-400 hover:bg-white/5 transition-all"
+                >
+                  Back
+                </button>
+              )}
+              <button
+                onClick={next}
+                className="px-6 py-2.5 rounded-xl text-sm font-semibold transition-all active:scale-[0.97] hover:opacity-90"
+                style={{
+                  background: accentHex,
+                  color: isDark ? '#000' : '#fff',
+                }}
+              >
+                {isLast ? 'Get started →' : 'Next →'}
+              </button>
+            </div>
+          </div>
+
+          {/* Progress dots */}
+          <div className="flex gap-1.5 mt-6 justify-center">
+            {TOUR_STEPS.map((_, i) => (
+              <button
+                key={i}
+                onClick={() => setStep(i)}
+                aria-label={`Go to step ${i + 1}`}
+                className="rounded-full transition-all duration-200"
+                style={{
+                  width: i === step ? '16px' : '6px',
+                  height: '6px',
+                  backgroundColor: i === step ? accentHex : i < step ? `${accentHex}55` : 'rgba(255,255,255,0.12)',
+                }}
+              />
+            ))}
+          </div>
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  )
+}


### PR DESCRIPTION
Adds a brief guided tour for new users and a feature preview modal on the login/signup pages.

**Changes:**
- `Tour.tsx`: 9-step animated guided tour modal (auto-triggers after signup, re-launchable from user menu)
- `FeaturePreview.tsx`: pre-login feature showcase grid accessible via "Explore features →" link
- `App.tsx`: first-time detection via localStorage flag, tour button in login/signup pages, "Take tour" in user menu

Closes #22

Generated with [Claude Code](https://claude.ai/code)