### PR TITLE
fix: make greeting popup last longer and match dark theme

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1210,6 +1210,12 @@ export default function App() {
       setTimeout(() => {
         toast.success(`Good ${g}, ${user.first_name}! 👋`, {
           description: streak > 0 ? `${streak}-day streak — keep it going!` : 'Ready to clock in?',
+          duration: 8000,
+          style: {
+            background: '#111111',
+            border: `1px solid ${getThemeAccentHex(theme)}`,
+            color: '#ffffff',
+          },
         })
       }, 1000)
     }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,6 +8,6 @@ import { Toaster } from 'sonner'
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />
-    <Toaster position="top-center" richColors closeButton />
+    <Toaster position="top-center" theme="dark" closeButton />
   </React.StrictMode>,
 )


### PR DESCRIPTION
Fixes #38

- Increase welcome popup duration from default ~4s to 8s
- Set popup background to dark (#111111) with theme-colored border matching current accent
- Switch Toaster to dark theme so all notifications match the app's black module style

Generated with [Claude Code](https://claude.ai/code)