### PR TITLE
feat: login improvements - demo banner, Google OAuth, forgot/reset password

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,20 +1,8 @@
-"""Auth routes: signup and signin.
+"""Auth routes: signup, signin, Google OAuth, forgot/reset password."""
+import time
+import uuid
 
-Users table (create if not exists on import):
-
-CREATE TABLE users (
-  id SERIAL PRIMARY KEY,
-  first_name TEXT NOT NULL,
-  last_name TEXT NOT NULL,
-  email TEXT UNIQUE NOT NULL,
-  password_hash TEXT NOT NULL,
-  job_role TEXT,
-  manager_name TEXT,
-  is_fulltime INTEGER DEFAULT 1,
-  pay REAL,
-  salary REAL
-);
-"""
+import requests as http_requests
 from flask import Blueprint, jsonify, request
 from werkzeug.security import generate_password_hash, check_password_hash
 
@@ -139,6 +127,24 @@ def _ensure_clock_sessions_table():
 _ensure_clock_sessions_table()
 
 
+def _ensure_password_reset_tokens_table():
+    with get_db() as db:
+        db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS password_reset_tokens (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              user_id INTEGER NOT NULL,
+              token TEXT UNIQUE NOT NULL,
+              expires_at INTEGER NOT NULL,
+              used INTEGER DEFAULT 0
+            )
+            """
+        )
+
+
+_ensure_password_reset_tokens_table()
+
+
 @bp.route("/signup", methods=["POST"])
 def signup():
     data = request.get_json() or {}
@@ -184,3 +190,108 @@ def signin():
         "pay": row.get("pay"),
         "salary": row.get("salary"),
     })
+
+
+@bp.route("/google", methods=["POST"])
+def google_auth():
+    data = request.get_json() or {}
+    access_token = data.get("access_token")
+    if not access_token:
+        return jsonify({"error": "access_token required"}), 400
+
+    try:
+        resp = http_requests.get(
+            "https://www.googleapis.com/oauth2/v3/userinfo",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=10,
+        )
+        if not resp.ok:
+            return jsonify({"error": "Invalid Google token"}), 401
+        google_user = resp.json()
+    except Exception:
+        return jsonify({"error": "Google verification failed"}), 500
+
+    email = google_user.get("email", "")
+    given_name = google_user.get("given_name") or ""
+    family_name = google_user.get("family_name") or ""
+    if not email:
+        return jsonify({"error": "Email not provided by Google"}), 400
+
+    with get_db() as db:
+        row = db.execute("SELECT * FROM users WHERE email = ?", (email,)).fetchone()
+        if not row:
+            row = db.execute(
+                "INSERT INTO users (first_name, last_name, email, password_hash, is_fulltime)"
+                " VALUES (?, ?, ?, ?, 1)"
+                " RETURNING id, first_name, last_name, email, job_role, manager_name, is_fulltime, pay, salary",
+                (given_name or "Google", family_name or "User", email, "google-oauth"),
+            ).fetchone()
+
+    return jsonify({
+        "id": row["id"],
+        "first_name": row["first_name"],
+        "last_name": row["last_name"],
+        "email": row["email"],
+        "job_role": row.get("job_role"),
+        "manager_name": row.get("manager_name"),
+        "is_fulltime": row.get("is_fulltime", 1),
+        "pay": row.get("pay"),
+        "salary": row.get("salary"),
+    })
+
+
+@bp.route("/forgot-password", methods=["POST"])
+def forgot_password():
+    data = request.get_json() or {}
+    email = (data.get("email") or "").strip().lower()
+    if not email:
+        return jsonify({"error": "email required"}), 400
+
+    with get_db() as db:
+        row = db.execute("SELECT id FROM users WHERE LOWER(email) = ?", (email,)).fetchone()
+        if not row:
+            return jsonify({"message": "If that email is registered, a reset link has been generated."})
+
+        token = str(uuid.uuid4())
+        expires_at = int(time.time()) + 3600  # 1 hour expiry
+        db.execute(
+            "INSERT INTO password_reset_tokens (user_id, token, expires_at) VALUES (?, ?, ?)",
+            (row["id"], token, expires_at),
+        )
+        db.commit()
+
+    reset_url = f"reset-password?token={token}"
+    return jsonify({
+        "message": "Reset link generated.",
+        "reset_url": reset_url,
+    })
+
+
+@bp.route("/reset-password", methods=["POST"])
+def reset_password():
+    data = request.get_json() or {}
+    token = (data.get("token") or "").strip()
+    new_password = data.get("password") or ""
+
+    if not token or not new_password:
+        return jsonify({"error": "token and password required"}), 400
+    if len(new_password) < 8:
+        return jsonify({"error": "Password must be at least 8 characters"}), 400
+
+    with get_db() as db:
+        row = db.execute(
+            "SELECT * FROM password_reset_tokens WHERE token = ? AND used = 0",
+            (token,),
+        ).fetchone()
+
+        if not row:
+            return jsonify({"error": "Invalid or already-used reset link"}), 400
+        if int(time.time()) > row["expires_at"]:
+            return jsonify({"error": "Reset link has expired. Please request a new one."}), 400
+
+        pw_hash = generate_password_hash(new_password)
+        db.execute("UPDATE users SET password_hash = ? WHERE id = ?", (pw_hash, row["user_id"]))
+        db.execute("UPDATE password_reset_tokens SET used = 1 WHERE token = ?", (token,))
+        db.commit()
+
+    return jsonify({"message": "Password updated successfully."})

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SwiftShift</title>
+    <script src="https://accounts.google.com/gsi/client" async></script>
   </head>
   <body style="background:#0A0F1E;color:#fff;margin:0;min-height:100vh">
     <div id="root"></div>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,12 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
-  <rect width="64" height="64" rx="14" fill="#000"/>
-  <!-- Clock ring (time) -->
-  <circle cx="32" cy="32" r="26" stroke="#d7fe51" stroke-width="2.5" fill="none"/>
-  <!-- Clock tick marks -->
-  <rect x="30.5" y="9" width="3" height="6" rx="1.5" fill="#d7fe51" opacity="0.75"/>
-  <rect x="49" y="30.5" width="6" height="3" rx="1.5" fill="#d7fe51" opacity="0.75"/>
-  <rect x="30.5" y="49" width="3" height="6" rx="1.5" fill="#d7fe51" opacity="0.75"/>
-  <rect x="9" y="30.5" width="6" height="3" rx="1.5" fill="#d7fe51" opacity="0.75"/>
-  <!-- Lightning bolt (speed + AI) -->
-  <path d="M 37 8 L 22 34 L 32 34 L 26 56 L 46 30 L 35 30 Z" fill="#d7fe51"/>
+  <rect width="64" height="64" rx="14" fill="#0a0a0a"/>
+  <circle cx="32" cy="32" r="27" stroke="white" stroke-width="1.5"/>
+  <path d="M 37 9 L 22 35 L 33 35 L 26 55 L 47 29 L 35 29 Z" fill="white"/>
 </svg>

--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -1,29 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" fill="none">
-  <!-- Clock ring (time) -->
-  <circle cx="100" cy="100" r="90" fill="#000" stroke="#d7fe51" stroke-width="3.5"/>
-
-  <!-- Clock tick marks at 12, 3, 6, 9 -->
-  <rect x="97.5" y="18" width="5" height="14" rx="2.5" fill="#d7fe51" opacity="0.75"/>
-  <rect x="168" y="97.5" width="14" height="5" rx="2.5" fill="#d7fe51" opacity="0.75"/>
-  <rect x="97.5" y="168" width="5" height="14" rx="2.5" fill="#d7fe51" opacity="0.75"/>
-  <rect x="18" y="97.5" width="14" height="5" rx="2.5" fill="#d7fe51" opacity="0.75"/>
-
-  <!-- Clock hour hand pointing to ~10 o'clock (time) -->
-  <line x1="100" y1="100" x2="58" y2="60" stroke="#d7fe51" stroke-width="4" stroke-linecap="round" opacity="0.55"/>
-
-  <!-- Lightning bolt (speed) — the dominant shape -->
-  <path d="M 117 28 L 80 108 L 105 108 L 88 172 L 138 88 L 111 88 Z" fill="#d7fe51"/>
-  <!-- Inner depth shadow -->
-  <path d="M 117 44 L 88 108 L 107 108 L 93 153 L 130 94 L 109 94 Z" fill="#000" opacity="0.22"/>
-
-  <!-- Center hub -->
-  <circle cx="100" cy="100" r="6" fill="#d7fe51"/>
-  <circle cx="100" cy="100" r="3" fill="#000"/>
-
-  <!-- AI circuit nodes (artificial intelligence) -->
-  <circle cx="42" cy="65" r="5" fill="#d7fe51" opacity="0.8"/>
-  <line x1="46" y1="68" x2="68" y2="82" stroke="#d7fe51" stroke-width="1.8" opacity="0.45" stroke-linecap="round"/>
-
-  <circle cx="156" cy="148" r="5" fill="#d7fe51" opacity="0.8"/>
-  <line x1="152" y1="144" x2="132" y2="126" stroke="#d7fe51" stroke-width="1.8" opacity="0.45" stroke-linecap="round"/>
+  <circle cx="100" cy="100" r="100" fill="#0a0a0a"/>
+  <circle cx="100" cy="100" r="86" stroke="white" stroke-width="2"/>
+  <path d="M 116 28 L 70 108 L 102 108 L 80 172 L 146 90 L 112 90 Z" fill="white"/>
 </svg>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -165,3 +165,98 @@
   color: rgba(255, 255, 255, 0.4);
   text-align: center;
 }
+
+/* ============================================
+   MOBILE HAMBURGER BUTTON
+   ============================================ */
+
+.ta-hamburger {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  width: 36px;
+  height: 36px;
+  padding: 6px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.ta-hamburger span {
+  display: block;
+  width: 20px;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 2px;
+  transition: all 0.2s ease;
+}
+
+/* ============================================
+   MOBILE SIDEBAR OVERLAY
+   ============================================ */
+
+.ta-sidebar-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 99;
+  backdrop-filter: blur(2px);
+}
+
+/* ============================================
+   MOBILE RESPONSIVE
+   ============================================ */
+
+@media (max-width: 767px) {
+  /* Show hamburger on mobile */
+  .ta-hamburger {
+    display: flex;
+  }
+
+  /* Sidebar slides in from left on mobile */
+  .ta-sidebar {
+    transform: translateX(-100%);
+    transition: transform 0.25s cubic-bezier(0.23, 1, 0.32, 1);
+    z-index: 150;
+    width: 260px;
+    top: 0;
+    padding-top: 80px;
+  }
+
+  .ta-sidebar.mobile-open {
+    transform: translateX(0);
+  }
+
+  /* Show backdrop when sidebar is open */
+  .ta-sidebar-backdrop.mobile-open {
+    display: block;
+  }
+
+  /* Content takes full width */
+  .ta-content {
+    margin-left: 0;
+  }
+
+  /* Reduce main padding on mobile */
+  .ta-main {
+    padding: 16px;
+  }
+
+  /* Compact navbar on mobile */
+  .ta-navbar {
+    padding: 10px 16px;
+  }
+
+  /* Hide streak badge label on small screens */
+  .ta-streak-label {
+    display: none;
+  }
+
+  /* Compact navbar user section */
+  .ta-navbar-user {
+    gap: 8px;
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import ReactMarkdown from 'react-markdown'
 import './App.css'
 import './index.css'
@@ -278,11 +278,16 @@ function TimesheetView({ user }: { user: any }) {
 
   const handleSaveDraft = () => {
     setDraftMessage('Draft saved')
+    toast.success('Draft saved! ✓', { description: 'Your hours are saved. Submit when ready.' })
   }
 
   const handleSubmit = () => {
     if (certified && !isSubmitted) {
       setSubmittedPeriods(prev => new Set(prev).add(periodId))
+      toast.success('Timesheet submitted! 🎉', { description: 'Your manager will review it shortly.' })
+      confetti({ particleCount: 150, spread: 90, origin: { y: 0.5 } })
+      setTimeout(() => confetti({ particleCount: 100, spread: 70, angle: 75, origin: { x: 0.2, y: 0.6 } }), 150)
+      setTimeout(() => confetti({ particleCount: 100, spread: 70, angle: 105, origin: { x: 0.8, y: 0.6 } }), 300)
     }
   }
 
@@ -360,12 +365,13 @@ function TimesheetView({ user }: { user: any }) {
 
       {/* Timecards table (14-day period) */}
       <div className="glass rounded-3xl overflow-hidden">
-        <div className="px-6 py-3 border-b border-white/10 flex justify-between text-xs uppercase tracking-[1px] text-zinc-400">
+        <div className="overflow-x-auto">
+        <div className="px-6 py-3 border-b border-white/10 flex justify-between text-xs uppercase tracking-[1px] text-zinc-400" style={{ minWidth: '700px' }}>
           {dayNames.map((n, i) => (
             <div key={i} className="text-center">{n}</div>
           ))}
         </div>
-        <div className="px-6 py-4 flex justify-between gap-3">
+        <div className="px-6 py-4 flex justify-between gap-3" style={{ minWidth: '700px' }}>
           {dayDates.map((d, i) => {
             const key = entryKey(periodId, i)
             const val = entries[key] || ''
@@ -389,6 +395,7 @@ function TimesheetView({ user }: { user: any }) {
               </div>
             )
           })}
+        </div>
         </div>
       </div>
 
@@ -1342,6 +1349,12 @@ export default function App() {
   const [taxFormData, setTaxFormData] = useState<any | null>(null)
   const [taxLoading, setTaxLoading] = useState(false)
   const [selectedDoc, setSelectedDoc] = useState<{ label: string; content: string } | null>(null)
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+
+  const navTo = (view: View) => {
+    setActiveView(view)
+    setMobileMenuOpen(false)
+  }
 
   const orgData = {
     id: 'ceo',
@@ -1436,7 +1449,7 @@ export default function App() {
 
   useTimesheet() // runs side effects (seeding)
 
-  // Clear tour-pending flag once tour is displayed
+  // Clear tour-pending flag and mark as seen once tour is displayed
   useEffect(() => {
     if (showTour) {
       localStorage.removeItem('swiftshift-tour-pending')
@@ -1500,6 +1513,12 @@ export default function App() {
   const [now, setNow] = useState(new Date())
   const [_shockwaveActive, setShockwaveActive] = useState(false)
   const [ripplePos, setRipplePos] = useState<{ x: number; y: number } | null>(null)
+
+  // Milestone tracking refs (persist across renders, reset on new clock session)
+  const hoursMilestoneFiredRef = useRef<Set<number>>(new Set())
+  const earningsMilestoneFiredRef = useRef<Set<number>>(new Set())
+  const progressMilestoneFiredRef = useRef<Set<number>>(new Set())
+  const loginWelcomeShownRef = useRef(false)
 
   // LootDrop modal state (shown after clock out)
   const [showLootDrop, setShowLootDrop] = useState(false)
@@ -1585,6 +1604,84 @@ export default function App() {
       ? 'On break'
       : `Clocked in since ${clockInAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`
 
+  // One-time login welcome toast
+  useEffect(() => {
+    if (!loginWelcomeShownRef.current) {
+      loginWelcomeShownRef.current = true
+      const hour = new Date().getHours()
+      const g = hour < 12 ? 'morning' : hour < 17 ? 'afternoon' : 'evening'
+      setTimeout(() => {
+        toast.success(`Good ${g}, ${user.first_name}! 👋`, {
+          description: streak > 0 ? `${streak}-day streak — keep it going!` : 'Ready to clock in?',
+          duration: 8000,
+          style: {
+            background: '#111111',
+            border: `1px solid ${getThemeAccentHex(theme)}`,
+            color: '#ffffff',
+          },
+        })
+      }, 1000)
+    }
+  }, [])
+
+  // Hourly milestone toasts (fire each time a new whole hour is crossed)
+  useEffect(() => {
+    if (!isClockedIn) return
+    const hoursWorked = Math.floor(todayTotalMs / 3600000)
+    if (hoursWorked >= 1 && !hoursMilestoneFiredRef.current.has(hoursWorked)) {
+      hoursMilestoneFiredRef.current.add(hoursWorked)
+      const hourMsgs: Record<number, string> = {
+        1: '1 hour in — nice start!',
+        2: '2 hours down!',
+        3: '3 hours — you\'re in the zone!',
+        4: 'Halfway there — 4 hours! 💪',
+        5: '5 hours — almost done!',
+        6: '6 hours — strong work!',
+        7: '7 hours — one more to go!',
+        8: 'Full 8-hour day complete! 🎉',
+      }
+      toast.success(hourMsgs[hoursWorked] || `${hoursWorked} hours worked!`, {
+        description: `Keep it up, ${user.first_name}!`,
+      })
+    }
+  }, [Math.floor(todayTotalMs / 3600000)])
+
+  // 25% / 50% / 75% daily goal progress toasts
+  useEffect(() => {
+    if (!isClockedIn) return
+    const EIGHT_HOURS_MS = 8 * 3600000
+    const pct = Math.floor((todayTotalMs / EIGHT_HOURS_MS) * 100)
+    const milestones = [25, 50, 75]
+    for (const m of milestones) {
+      if (pct >= m && !progressMilestoneFiredRef.current.has(m)) {
+        progressMilestoneFiredRef.current.add(m)
+        const msgs: Record<number, string> = {
+          25: '25% of your day done! 🏁',
+          50: 'Halfway through your day! ⚡',
+          75: '75% complete — almost there! 🚀',
+        }
+        toast.success(msgs[m], { description: `${user.first_name}, you're crushing it!` })
+        confetti({ particleCount: 40, spread: 45, origin: { y: 0.75 }, colors: [themeAccentHex] })
+        break
+      }
+    }
+  }, [Math.floor((todayTotalMs / (8 * 3600000)) * 4)])
+
+  // Earnings milestone toasts ($50, $100, $200, $400)
+  useEffect(() => {
+    if (!isClockedIn) return
+    const earnings = (todayTotalMs / 3600000) * 65
+    const milestones = [50, 100, 200, 400]
+    for (const m of milestones) {
+      if (earnings >= m && !earningsMilestoneFiredRef.current.has(m)) {
+        earningsMilestoneFiredRef.current.add(m)
+        toast.success(`$${m} earned today! 💰`, { description: 'Your wallet is growing.' })
+        confetti({ particleCount: 60, spread: 50, origin: { y: 0.7 }, colors: [themeAccentHex, '#FFD700'] })
+        break
+      }
+    }
+  }, [Math.floor((todayTotalMs / 3600000) * 65 / 50)])
+
   // Pay period
   const period = useMemo(() => payPeriodFor(now), [now])
   const periodLabel = `${period.start.toLocaleDateString([], { month: '2-digit', day: '2-digit', year: 'numeric' })} – ${period.end.toLocaleDateString([], { month: '2-digit', day: '2-digit', year: 'numeric' })}`
@@ -1618,7 +1715,33 @@ export default function App() {
         setLastStreakDate(todayStr)
         localStorage.setItem('streak', String(newStreak))
         localStorage.setItem('lastStreakDate', todayStr)
+
+        // Streak milestone celebrations
+        if ([5, 10, 20, 30, 50].includes(newStreak)) {
+          setTimeout(() => {
+            confetti({ particleCount: 300, spread: 120, origin: { y: 0.5 }, colors: [themeAccentHex, '#FFD700', '#FF6B6B'] })
+            setTimeout(() => confetti({ particleCount: 200, spread: 80, origin: { y: 0.65 }, colors: [themeAccentHex, '#FFD700'] }), 200)
+          }, 400)
+          toast.success(`🔥 ${newStreak}-day streak milestone!`, {
+            description: newStreak >= 20 ? 'You\'re absolutely legendary!' : newStreak >= 10 ? 'You\'re on fire! Incredible consistency!' : 'High five! Keep that streak alive!',
+          })
+        } else {
+          // Regular clock-in toast
+          toast.success(`Clocked in! Let's go, ${user.first_name}!`, {
+            description: newStreak > 1 ? `${newStreak}-day streak 🔥` : 'Time to make it count!',
+          })
+        }
+      } else {
+        // Weekend clock-in toast (no streak tracking)
+        toast.success(`Clocked in! Working the weekend, ${user.first_name}?`, {
+          description: 'Dedication noted! 💪',
+        })
       }
+
+      // Reset milestone trackers for new session
+      hoursMilestoneFiredRef.current = new Set()
+      earningsMilestoneFiredRef.current = new Set()
+      progressMilestoneFiredRef.current = new Set()
 
       // Capture button center for ripple origin
       if (e?.currentTarget) {
@@ -1650,6 +1773,17 @@ export default function App() {
       const delta = Math.max(0, now.getTime() - breakStartedAt.getTime())
       setBreakMsAccum(v => v + delta)
       setBreakStartedAt(null)
+      const breakMins = Math.round(delta / 60000)
+      const msgs = [
+        "You're back — let's get it!",
+        "Refreshed and ready to crush it!",
+        "Break over — back to greatness!",
+        "Recharged! Time to earn! ⚡",
+        "Welcome back — you've got this!",
+      ]
+      toast.success(msgs[Math.floor(Math.random() * msgs.length)], {
+        description: `Break: ${breakMins} min`,
+      })
     }
   }
 
@@ -1786,23 +1920,35 @@ export default function App() {
   return (
     <div className="ta-app" data-theme={theme}>
       <nav className="ta-navbar">
-        <div className="ta-navbar-brand cursor-pointer" onClick={() => setActiveView('clock')}>
-          <LogoSVG className="h-10 w-auto" />
-          <span>SwiftShift</span>
+        <div className="flex items-center gap-2">
+          {/* Hamburger (mobile only) */}
+          <button
+            className="ta-hamburger"
+            onClick={() => setMobileMenuOpen(o => !o)}
+            aria-label="Toggle menu"
+          >
+            <span />
+            <span />
+            <span />
+          </button>
+          <div className="ta-navbar-brand cursor-pointer" onClick={() => navTo('clock')}>
+            <LogoSVG className="h-10 w-auto" />
+            <span>SwiftShift</span>
+          </div>
         </div>
         <div className="ta-navbar-user">
           {/* Daily streak counter */}
           <div className="flex items-center gap-1.5 px-3 py-1 text-sm text-white/60 border border-white/10 rounded-full">
             <span style={{ color: 'var(--accent-color)' }}>{streak > 0 ? '🔥' : '○'}</span>
             <span className="font-semibold" style={{ color: 'var(--accent-color)' }}>{streak}</span>
-            <span className="text-white/40">day streak</span>
+            <span className="text-white/40 ta-streak-label">day streak</span>
           </div>
           {/* User menu dropdown */}
           <div className="relative group">
             <span className="text-sm text-zinc-400 cursor-pointer">Hi, {user.first_name} ▾</span>
             <div className="absolute right-0 top-full w-48 bg-zinc-900 border border-white/10 rounded-xl shadow-lg hidden group-hover:block z-50 pt-1">
               <button
-                onClick={() => setActiveView('profile')}
+                onClick={() => navTo('profile')}
                 className="w-full text-left px-4 py-2 text-sm hover:bg-white/5 rounded-t-xl"
               >
                 Profile
@@ -1840,11 +1986,17 @@ export default function App() {
         </div>
       </nav>
 
-      <aside className="ta-sidebar">
+      {/* Mobile sidebar backdrop */}
+      <div
+        className={`ta-sidebar-backdrop ${mobileMenuOpen ? 'mobile-open' : ''}`}
+        onClick={() => setMobileMenuOpen(false)}
+      />
+
+      <aside className={`ta-sidebar ${mobileMenuOpen ? 'mobile-open' : ''}`}>
         <nav className="ta-nav">
           <button
             className={`ta-nav-btn ${activeView === 'clock' ? 'active' : ''}`}
-            onClick={() => setActiveView('clock')}
+            onClick={() => navTo('clock')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
@@ -1853,7 +2005,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'timesheet' ? 'active' : ''}`}
-            onClick={() => setActiveView('timesheet')}
+            onClick={() => navTo('timesheet')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/>
@@ -1862,7 +2014,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'rewards' ? 'active' : ''}`}
-            onClick={() => setActiveView('rewards')}
+            onClick={() => navTo('rewards')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/>
@@ -1871,7 +2023,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'insurance' ? 'active' : ''}`}
-            onClick={() => setActiveView('insurance')}
+            onClick={() => navTo('insurance')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
@@ -1880,7 +2032,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'orgchart' ? 'active' : ''}`}
-            onClick={() => setActiveView('orgchart')}
+            onClick={() => navTo('orgchart')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <rect x="8" y="2" width="8" height="4" rx="1"/><rect x="2" y="14" width="8" height="4" rx="1"/><rect x="14" y="14" width="8" height="4" rx="1"/><line x1="12" y1="6" x2="12" y2="11"/><line x1="6" y1="14" x2="6" y2="11"/><line x1="18" y1="14" x2="18" y2="11"/><line x1="6" y1="11" x2="18" y2="11"/>
@@ -1889,7 +2041,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'taxes' ? 'active' : ''}`}
-            onClick={() => setActiveView('taxes')}
+            onClick={() => navTo('taxes')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <path d="M22 19a2 2 0 01-2 2H4a2 2 0 01-2-2V5a2 2 0 012-2h5l2 3h9a2 2 0 012 2z"/>
@@ -1898,7 +2050,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn mb-2 ${activeView === 'groktax' ? 'active' : ''}`}
-            onClick={() => setActiveView('groktax')}
+            onClick={() => navTo('groktax')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6"/>
@@ -1908,7 +2060,7 @@ export default function App() {
           <div className="ta-nav-section">Job Applications</div>
           <button
             className={`ta-nav-btn mb-2 ${activeView === 'applications' ? 'active' : ''}`}
-            onClick={() => setActiveView('applications')}
+            onClick={() => navTo('applications')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
@@ -1918,7 +2070,7 @@ export default function App() {
           <div className="ta-nav-section">Admin</div>
           <button
             className={`ta-nav-btn ${activeView === 'admin' ? 'active' : ''}`}
-            onClick={() => setActiveView('admin')}
+            onClick={() => navTo('admin')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/>
@@ -1927,7 +2079,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'schedules' ? 'active' : ''}`}
-            onClick={() => setActiveView('schedules')}
+            onClick={() => navTo('schedules')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/>
@@ -1936,7 +2088,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'payroll' ? 'active' : ''}`}
-            onClick={() => setActiveView('payroll')}
+            onClick={() => navTo('payroll')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <rect x="2" y="5" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/>
@@ -1945,7 +2097,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'reports' ? 'active' : ''}`}
-            onClick={() => setActiveView('reports')}
+            onClick={() => navTo('reports')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/>
@@ -1954,7 +2106,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'leaves' ? 'active' : ''}`}
-            onClick={() => setActiveView('leaves')}
+            onClick={() => navTo('leaves')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/>
@@ -1963,7 +2115,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'compliance' ? 'active' : ''}`}
-            onClick={() => setActiveView('compliance')}
+            onClick={() => navTo('compliance')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/>
@@ -1972,7 +2124,7 @@ export default function App() {
           </button>
           <button
             className={`ta-nav-btn ${activeView === 'hiring' ? 'active' : ''}`}
-            onClick={() => setActiveView('hiring')}
+            onClick={() => navTo('hiring')}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
               <path d="M16 21v-2a4 4 0 00-4-4H6a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><line x1="19" y1="8" x2="19" y2="14"/><line x1="22" y1="11" x2="16" y2="11"/>
@@ -1983,7 +2135,7 @@ export default function App() {
         <div className="mt-auto pt-4">
           <button
             className={`ta-nav-btn ${activeView === 'grokky' ? 'active' : ''}`}
-            onClick={() => setActiveView('grokky')}
+            onClick={() => navTo('grokky')}
             style={{ color: 'var(--accent-color)', textShadow: '0 0 8px var(--accent-color)' }}
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
@@ -1998,12 +2150,12 @@ export default function App() {
         <main className="ta-main">
           {activeView === 'clock' && (
             <>
-              <div className="flex gap-6 items-stretch max-w-[1200px] mx-auto">
+              <div className="flex flex-col xl:flex-row gap-6 items-stretch max-w-[1200px] mx-auto">
               {/* Left: Dashboard */}
               <div className="flex-1 space-y-6">
                 {/* Dashboard card */}
-                <div className="glass rounded-3xl p-8">
-                  <div className="flex items-start gap-10">
+                <div className="glass rounded-3xl p-5 sm:p-8">
+                  <div className="flex flex-col sm:flex-row items-start gap-6 sm:gap-10">
                     {/* Left: Greeting, Time, Status, Buttons */}
                     <div className="flex-1">
                       <div className="text-sm text-zinc-400 mb-1">{longDate(now)}</div>
@@ -2011,7 +2163,7 @@ export default function App() {
                         {greeting(now.getHours())}, {user.first_name}
                       </div>
 
-                      <div className="font-mono text-6xl tabular-nums tracking-[2px] mb-6">
+                      <div className="font-mono text-4xl sm:text-6xl tabular-nums tracking-[2px] mb-6">
                         {now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
                       </div>
 
@@ -2024,31 +2176,35 @@ export default function App() {
 
                   <div className="flex flex-wrap gap-3">
                     {!isClockedIn && (
-                      <button
+                      <motion.button
                         onClick={handleClockIn}
                         className="glass-btn-green px-5 py-2.5 rounded-xl font-semibold active:scale-[0.96] transition-all duration-75"
+                        whileHover={{ scale: 1.04 }}
+                        whileTap={{ scale: 0.95 }}
+                        animate={{ boxShadow: ['0 0 0px rgba(var(--accent-color-rgb),0)', '0 0 18px 4px rgba(var(--accent-color-rgb),0.35)', '0 0 0px rgba(var(--accent-color-rgb),0)'] }}
+                        transition={{ boxShadow: { repeat: Infinity, duration: 2, ease: 'easeInOut' } }}
                       >
                         Clock in
-                      </button>
+                      </motion.button>
                     )}
                     {isClockedIn && !isOnBreak && (
                       <>
-                        <button onClick={handleStartBreak} className="px-5 py-2.5 rounded-xl border border-white/20 hover:bg-white/5">
+                        <motion.button onClick={handleStartBreak} className="px-5 py-2.5 rounded-xl border border-white/20 hover:bg-white/5" whileHover={{ scale: 1.03 }} whileTap={{ scale: 0.97 }}>
                           Start break
-                        </button>
-                        <button onClick={handleClockOut} className="px-5 py-2.5 rounded-xl bg-red-500/80 hover:bg-red-500 text-white">
+                        </motion.button>
+                        <motion.button onClick={handleClockOut} className="px-5 py-2.5 rounded-xl bg-red-500/80 hover:bg-red-500 text-white" whileHover={{ scale: 1.03 }} whileTap={{ scale: 0.97 }}>
                           Clock out
-                        </button>
+                        </motion.button>
                       </>
                     )}
                     {isOnBreak && (
                       <>
-                        <button onClick={handleEndBreak} className="px-5 py-2.5 rounded-xl border border-white/20 hover:bg-white/5">
+                        <motion.button onClick={handleEndBreak} className="px-5 py-2.5 rounded-xl border border-white/20 hover:bg-white/5" whileHover={{ scale: 1.03 }} whileTap={{ scale: 0.97 }}>
                           End break
-                        </button>
-                        <button onClick={handleClockOut} className="px-5 py-2.5 rounded-xl bg-red-500/80 hover:bg-red-500 text-white">
+                        </motion.button>
+                        <motion.button onClick={handleClockOut} className="px-5 py-2.5 rounded-xl bg-red-500/80 hover:bg-red-500 text-white" whileHover={{ scale: 1.03 }} whileTap={{ scale: 0.97 }}>
                           Clock out
-                        </button>
+                        </motion.button>
                       </>
                     )}
                   </div>
@@ -2124,10 +2280,18 @@ export default function App() {
                     </div>
                   </div>
 
-                  <div className="mt-6 grid grid-cols-3 gap-4 text-sm">
+                  <div className="mt-6 grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
                     <div className="glass rounded-2xl p-4">
                       <div className="text-zinc-400 mb-1">Session</div>
-                      <div className="font-mono text-xl neon-green">{formatMs(sessionWorkedMs)}</div>
+                      <motion.div
+                        key={Math.floor(sessionWorkedMs / 60000)}
+                        initial={isClockedIn && !isOnBreak ? { opacity: 0.6 } : false}
+                        animate={{ opacity: 1 }}
+                        transition={{ duration: 0.3 }}
+                        className="font-mono text-xl neon-green"
+                      >
+                        {formatMs(sessionWorkedMs)}
+                      </motion.div>
                     </div>
                     <div className="glass rounded-2xl p-4">
                       <div className="text-zinc-400 mb-1">Breaks</div>
@@ -2138,18 +2302,34 @@ export default function App() {
                       <div className="font-mono text-xl neon-green">{formatMs(todayTotalMs)}</div>
                     </div>
                   </div>
+                  {/* Day progress bar */}
+                  {isClockedIn && (
+                    <div className="mt-4">
+                      <div className="flex justify-between text-xs text-zinc-500 mb-1">
+                        <span>Daily goal progress</span>
+                        <span>{Math.min(100, Math.round((todayTotalMs / (8 * 3600000)) * 100))}%</span>
+                      </div>
+                      <div className="crystal-progress">
+                        <motion.div
+                          className="crystal-progress-fill"
+                          animate={{ width: `${Math.min(100, (todayTotalMs / (8 * 3600000)) * 100)}%` }}
+                          transition={{ duration: 1, ease: 'easeOut' }}
+                        />
+                      </div>
+                    </div>
+                  )}
                 </div>
 
               </div>
 
               {/* Right sidebar: This pay period + Real Time Rewards */}
-              <aside className="w-80 shrink-0 flex flex-col gap-4">
+              <aside className="xl:w-80 shrink-0 flex flex-col sm:flex-row xl:flex-col gap-4">
                 <div className="glass rounded-3xl p-8 flex-1">
                   <div className="text-sm uppercase tracking-[2px] text-white mb-3">This pay period</div>
                   <div className="text-lg font-medium mb-2 neon-green">{periodLabel}</div>
                   <div className="text-sm text-zinc-400 mb-4">Regular hours: <span className="font-mono neon-green">{periodHours}</span> hrs</div>
                   <button
-                    onClick={() => setActiveView('timesheet')}
+                    onClick={() => navTo('timesheet')}
                     className="text-sm underline decoration-white/30 hover:decoration-white"
                   >
                     See my time →
@@ -2159,20 +2339,35 @@ export default function App() {
                 {/* Real Time Rewards module */}
                 <div className="glass rounded-3xl p-8 flex-1">
                   <div className="text-sm uppercase tracking-[2px] text-white mb-3">Real Time Rewards</div>
-                  <div className="flex justify-between items-center mb-2">
-                    <div className="text-sm text-zinc-400">Today's Earnings:</div>
-                    <div className="h-6 rounded-b-lg flex items-center justify-center text-xs font-semibold px-3 bg-black neon-green">
+                  <div className="mb-3">
+                    <div className="text-xs text-zinc-400 mb-1">Today's Earnings</div>
+                    <motion.div
+                      key={Math.floor((todayTotalMs / 3600000) * 65 * 10)}
+                      initial={isClockedIn ? { scale: 1.08, color: 'var(--accent-color)' } : false}
+                      animate={{ scale: 1, color: 'var(--accent-color)' }}
+                      transition={{ duration: 0.25 }}
+                      className="font-mono text-2xl font-semibold tabular-nums neon-green"
+                    >
                       ${((todayTotalMs / 3600000) * 65).toFixed(2)}
-                    </div>
+                    </motion.div>
+                    {isClockedIn && (
+                      <div className="flex items-center gap-1.5 mt-0.5">
+                        <span
+                          className="w-2.5 h-2.5 rounded-full animate-pulse inline-block"
+                          style={{ background: '#22ff7a', boxShadow: '0 0 8px #22ff7a, 0 0 16px #22ff7a60' }}
+                        />
+                        <span className="text-xs uppercase tracking-widest text-zinc-300 font-medium">live</span>
+                      </div>
+                    )}
                   </div>
                   <div className="flex justify-between items-center mb-4">
-                    <div className="text-sm text-zinc-400">Today's PTO Accrued:</div>
-                    <div className="h-6 rounded-b-lg flex items-center justify-center text-xs font-semibold px-3 bg-black neon-green">
-                      {((todayTotalMs / 3600000) / 30).toFixed(2)} hrs
+                    <div className="text-sm text-zinc-400">PTO Accrued:</div>
+                    <div className="text-sm font-semibold neon-green">
+                      {((todayTotalMs / 3600000) / 30).toFixed(3)} hrs
                     </div>
                   </div>
                   <button
-                    onClick={() => setActiveView('rewards')}
+                    onClick={() => navTo('rewards')}
                     className="text-sm underline decoration-white/30 hover:decoration-white"
                   >
                     See rewards →
@@ -2198,7 +2393,7 @@ export default function App() {
           {activeView === 'admin' && (
             <div className="max-w-5xl mx-auto">
               <div className="glass rounded-3xl p-8">
-                <div className="flex items-center justify-between mb-6">
+                <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
                   <h1 className="text-2xl font-semibold neon-green">Admin: Manage Users</h1>
                   <button
                     onClick={() => {
@@ -2215,7 +2410,8 @@ export default function App() {
                     Save Changes
                   </button>
                 </div>
-                <table className="w-full text-xs">
+                <div className="overflow-x-auto">
+                <table className="w-full text-xs" style={{ minWidth: '700px' }}>
                   <thead>
                     <tr className="text-zinc-400 border-b border-white/10">
                       <th className="text-left py-1">First Name</th>
@@ -2318,13 +2514,14 @@ export default function App() {
                     ))}
                   </tbody>
                 </table>
+                </div>
                 {users.length === 0 && <div className="text-zinc-400 mt-4">No users yet.</div>}
               </div>
             </div>
           )}
           {activeView === 'schedules' && (
             <div className="max-w-5xl mx-auto space-y-6">
-              <div className="flex items-center justify-between">
+              <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <h1 className="text-2xl font-semibold neon-green">Schedule Management</h1>
                   <p className="text-sm text-zinc-400">Manage shifts and employee schedules</p>
@@ -2333,7 +2530,7 @@ export default function App() {
                   + Add Shift
                 </button>
               </div>
-              <div className="grid grid-cols-7 gap-2">
+              <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-2">
                 {['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'].map(day => (
                   <div key={day} className="glass rounded-2xl p-3">
                     <div className="text-xs font-semibold text-zinc-400 mb-2 uppercase">{day}</div>
@@ -2350,7 +2547,7 @@ export default function App() {
               </div>
               <div className="glass rounded-3xl p-6">
                 <h2 className="text-lg font-semibold mb-4" style={{ color: 'var(--accent-color)' }}>Shift Coverage Summary</h2>
-                <div className="grid grid-cols-3 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                   {[['Total Shifts This Week', '14'], ['Filled Shifts', '11'], ['Open Shifts', '3']].map(([label, val]) => (
                     <div key={label} className="bg-white/5 rounded-2xl p-4 text-center">
                       <div className="text-2xl font-bold" style={{ color: 'var(--accent-color)' }}>{val}</div>
@@ -2363,7 +2560,7 @@ export default function App() {
           )}
           {activeView === 'payroll' && (
             <div className="max-w-5xl mx-auto space-y-6">
-              <div className="flex items-center justify-between">
+              <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <h1 className="text-2xl font-semibold neon-green">Payroll</h1>
                   <p className="text-sm text-zinc-400">Current pay period: Apr 15 – Apr 30, 2026</p>
@@ -2372,7 +2569,7 @@ export default function App() {
                   Run Payroll
                 </button>
               </div>
-              <div className="grid grid-cols-4 gap-4">
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
                 {[['Total Payroll', '$48,320'], ['Employees Paid', '24'], ['Avg Hours/Employee', '38.5h'], ['Overtime Hours', '42h']].map(([label, val]) => (
                   <div key={label} className="glass rounded-2xl p-4 text-center">
                     <div className="text-2xl font-bold" style={{ color: 'var(--accent-color)' }}>{val}</div>
@@ -2382,7 +2579,8 @@ export default function App() {
               </div>
               <div className="glass rounded-3xl p-6">
                 <h2 className="text-lg font-semibold mb-4" style={{ color: 'var(--accent-color)' }}>Employee Payroll Summary</h2>
-                <table className="w-full text-sm">
+                <div className="overflow-x-auto">
+                <table className="w-full text-sm" style={{ minWidth: '500px' }}>
                   <thead>
                     <tr className="text-zinc-400 border-b border-white/10 text-left">
                       <th className="py-2">Employee</th>
@@ -2413,6 +2611,7 @@ export default function App() {
                     ))}
                   </tbody>
                 </table>
+                </div>
               </div>
             </div>
           )}
@@ -2422,7 +2621,7 @@ export default function App() {
                 <h1 className="text-2xl font-semibold neon-green">Reports &amp; Analytics</h1>
                 <p className="text-sm text-zinc-400">Workforce performance and operational insights</p>
               </div>
-              <div className="grid grid-cols-2 gap-6">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
                 {[
                   { title: 'Hours Worked (This Month)', value: '1,842h', change: '+4.2%', sub: 'vs last month' },
                   { title: 'Labor Cost (This Month)', value: '$94,600', change: '+1.8%', sub: 'vs last month' },
@@ -2446,7 +2645,7 @@ export default function App() {
                         <span className="text-zinc-400">{used}h / {total}h</span>
                       </div>
                       <div className="h-2 bg-white/10 rounded-full overflow-hidden">
-                        <div className="h-full rounded-full transition-all" style={{ width: `${Math.round((used as number / total as number) * 100)}%`, backgroundColor: 'var(--accent-color)' }} />
+                        <div className="h-full rounded-full transition-all" style={{ width: `${Math.round(((used as number) / (total as number)) * 100)}%`, backgroundColor: 'var(--accent-color)' }} />
                       </div>
                     </div>
                   ))}
@@ -2462,7 +2661,7 @@ export default function App() {
                   <p className="text-sm text-zinc-400">Manage PTO requests and absence tracking</p>
                 </div>
               </div>
-              <div className="grid grid-cols-4 gap-4">
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
                 {[['Pending Requests', '5'], ['Approved This Month', '12'], ['Denied This Month', '2'], ['Avg PTO Balance', '14.2 days']].map(([label, val]) => (
                   <div key={label} className="glass rounded-2xl p-4 text-center">
                     <div className="text-2xl font-bold" style={{ color: 'var(--accent-color)' }}>{val}</div>
@@ -2479,7 +2678,7 @@ export default function App() {
                     { name: 'Skyler Reed', type: 'Personal', dates: 'May 12, 2026', days: 1, status: 'Pending' },
                     { name: 'Avery Lane', type: 'Vacation', dates: 'May 19–23, 2026', days: 5, status: 'Pending' },
                     { name: 'Dakota Lane', type: 'Bereavement', dates: 'Apr 25–27, 2026', days: 3, status: 'Pending' },
-                  ].map(({ name, type, dates, days, status }) => (
+                  ].map(({ name, type, dates, days }) => (
                     <div key={name} className="flex items-center justify-between bg-white/5 rounded-xl px-4 py-3">
                       <div>
                         <div className="font-medium">{name}</div>
@@ -2501,7 +2700,7 @@ export default function App() {
                 <h1 className="text-2xl font-semibold neon-green">Compliance &amp; Audit</h1>
                 <p className="text-sm text-zinc-400">Policy compliance, certifications, and audit logs</p>
               </div>
-              <div className="grid grid-cols-3 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                 {[['Compliance Score', '94%'], ['Open Incidents', '2'], ['Overdue Trainings', '7']].map(([label, val]) => (
                   <div key={label} className="glass rounded-2xl p-4 text-center">
                     <div className="text-3xl font-bold" style={{ color: 'var(--accent-color)' }}>{val}</div>
@@ -2552,7 +2751,7 @@ export default function App() {
           )}
           {activeView === 'hiring' && (
             <div className="max-w-5xl mx-auto space-y-6">
-              <div className="flex items-center justify-between">
+              <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <h1 className="text-2xl font-semibold neon-green">Hiring &amp; Onboarding</h1>
                   <p className="text-sm text-zinc-400">Recruitment pipeline and new hire management</p>
@@ -2561,7 +2760,7 @@ export default function App() {
                   + Post Job
                 </button>
               </div>
-              <div className="grid grid-cols-4 gap-4">
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
                 {[['Open Positions', '6'], ['Active Applicants', '38'], ['Interviews This Week', '9'], ['Offers Pending', '3']].map(([label, val]) => (
                   <div key={label} className="glass rounded-2xl p-4 text-center">
                     <div className="text-2xl font-bold" style={{ color: 'var(--accent-color)' }}>{val}</div>
@@ -2569,7 +2768,7 @@ export default function App() {
                   </div>
                 ))}
               </div>
-              <div className="grid grid-cols-2 gap-6">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
                 <div className="glass rounded-3xl p-6">
                   <h2 className="text-lg font-semibold mb-4" style={{ color: 'var(--accent-color)' }}>Hiring Pipeline</h2>
                   <div className="space-y-3">
@@ -2768,21 +2967,21 @@ export default function App() {
           {activeView === 'orgchart' && (
             <div className="flex-1 flex flex-col">
               {/* Header bar */}
-              <div className="flex items-center justify-between px-6 py-4 border-b border-white/10">
+              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 px-4 sm:px-6 py-4 border-b border-white/10">
                 <div>
-                  <p className="text-xs text-zinc-400">Hover for details • Click ▶ to expand</p>
+                  <p className="text-xs text-zinc-400">Tap/hover for details • Tap ▶ to expand</p>
                 </div>
                 <div className="flex items-center gap-3">
                   <input
                     type="text"
                     placeholder="Search..."
-                    className="bg-white/5 rounded-xl px-3 py-1.5 text-sm focus:bg-white/10 focus:outline-none w-56"
+                    className="bg-white/5 rounded-xl px-3 py-1.5 text-sm focus:bg-white/10 focus:outline-none flex-1 sm:w-56"
                     value={orgSearch}
                     onChange={(e) => setOrgSearch(e.target.value)}
                   />
                   <button
                     onClick={() => setOrgExpandedAll(!orgExpandedAll)}
-                    className="text-xs px-3 py-1.5 rounded-lg bg-white/10 hover:bg-white/20 transition-colors"
+                    className="text-xs px-3 py-1.5 rounded-lg bg-white/10 hover:bg-white/20 transition-colors whitespace-nowrap"
                   >
                     {orgExpandedAll ? 'Collapse All' : 'Expand All'}
                   </button>
@@ -3139,7 +3338,7 @@ export default function App() {
               </div>
 
               {/* Resume Upload */}
-              <div className="glass rounded-3xl p-6 flex items-center justify-between">
+              <div className="glass rounded-3xl p-6 flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <div className="font-medium">Your Resume</div>
                   <div className="text-sm text-zinc-500">Upload once, apply everywhere</div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -458,6 +458,231 @@ function getThemeAccentHex(theme: string): string {
   return '#D7FE51'
 }
 
+const GOOGLE_CLIENT_ID = (import.meta as any).env?.VITE_GOOGLE_CLIENT_ID || ''
+
+// ===== Forgot Password Modal =====
+function ForgotPasswordModal({ onClose, accentHex }: { onClose: () => void; accentHex: string }) {
+  const [email, setEmail] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [sent, setSent] = useState(false)
+  const [resetUrl, setResetUrl] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+    try {
+      const res = await fetch(`${API_BASE}/api/auth/forgot-password`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error || 'Request failed. Please try again.')
+      } else {
+        setSent(true)
+        if (data.reset_url) setResetUrl(data.reset_url)
+      }
+    } catch {
+      setError('Connection failed. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 backdrop-blur-sm" onClick={onClose}>
+      <div className="glass w-full max-w-[360px] rounded-3xl p-8 border border-white/10 mx-4" onClick={e => e.stopPropagation()}>
+        <div className="flex items-center justify-between mb-5">
+          <h2 className="text-xl font-semibold">Reset Password</h2>
+          <button onClick={onClose} className="text-zinc-500 hover:text-white transition-colors" aria-label="Close">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+            </svg>
+          </button>
+        </div>
+        {sent ? (
+          <div className="text-center py-4 space-y-3">
+            <div className="text-4xl">📬</div>
+            <p className="text-sm text-zinc-400">
+              If that email is registered, a reset link has been generated.
+            </p>
+            {resetUrl && (
+              <div className="mt-3 p-3 rounded-xl bg-white/5 border border-white/10 text-left">
+                <p className="text-[11px] text-zinc-500 mb-1.5 uppercase tracking-wider">Your reset link (demo mode)</p>
+                <a
+                  href={resetUrl}
+                  className="text-xs break-all underline underline-offset-4 transition-colors"
+                  style={{ color: accentHex }}
+                >
+                  {window.location.origin}/{resetUrl}
+                </a>
+              </div>
+            )}
+            <button onClick={onClose} className="mt-2 text-sm underline underline-offset-4 text-zinc-400 hover:text-white transition-colors">
+              Back to sign in
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <p className="text-sm text-zinc-400">Enter your email and we'll generate a password reset link.</p>
+            <div>
+              <label className="block text-sm text-zinc-400 mb-1 tracking-wide">EMAIL</label>
+              <input
+                type="email"
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+                className="glass-input w-full rounded-2xl px-4 py-3 text-sm placeholder:text-zinc-600 border border-white/10 focus:border-white/40 outline-none transition-all"
+                placeholder="you@company.com"
+                required
+                autoFocus
+              />
+            </div>
+            {error && (
+              <div className="text-sm text-red-400 flex items-center gap-2 bg-red-950/40 border border-red-900/60 rounded-xl px-4 py-2">
+                ⚠ {error}
+              </div>
+            )}
+            <button
+              type="submit"
+              disabled={loading}
+              className="glass-btn-green w-full py-3 rounded-2xl text-sm font-semibold tracking-[0.5px] transition-all disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {loading ? 'Generating link…' : 'Send Reset Link'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ===== Reset Password Page =====
+function ResetPasswordPage() {
+  const token = new URLSearchParams(window.location.search).get('token') || ''
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+  const [showPassword, setShowPassword] = useState(false)
+  const accentHex = getThemeAccentHex(localStorage.getItem('theme') || 'green')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (password !== confirm) { setError("Passwords don't match"); return }
+    setError(null)
+    setLoading(true)
+    try {
+      const res = await fetch(`${API_BASE}/api/auth/reset-password`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, password }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error || 'Reset failed. The link may have expired.')
+      } else {
+        setSuccess(true)
+      }
+    } catch {
+      setError('Connection failed. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-black text-white flex items-center justify-center p-4 relative">
+      <div className="absolute inset-0 bg-gradient-to-br from-black via-[#0A0F1E] to-black" />
+      <div className="glass w-full max-w-[380px] rounded-3xl p-8 border border-white/10 relative z-10">
+        <div className="flex items-center gap-3 mb-6">
+          <LogoSVG className="h-8 w-auto" accentColor={accentHex} />
+          <span className="font-semibold text-xl tracking-[1px]">SWIFTSHIFT</span>
+        </div>
+        {!token ? (
+          <div className="text-center py-4 space-y-3">
+            <div className="text-4xl">⚠️</div>
+            <p className="text-sm text-zinc-400">Invalid reset link. Please request a new one.</p>
+            <a href="login" className="inline-block text-sm underline underline-offset-4 text-zinc-400 hover:text-white transition-colors">Back to sign in</a>
+          </div>
+        ) : success ? (
+          <div className="text-center py-4 space-y-3">
+            <div className="text-4xl">✅</div>
+            <p className="text-sm text-zinc-400">Password updated successfully!</p>
+            <a href="login" className="inline-block text-sm underline underline-offset-4 text-zinc-400 hover:text-white transition-colors">Sign in</a>
+          </div>
+        ) : (
+          <>
+            <div className="mb-5">
+              <div className="text-xs tracking-[2px] mb-1.5 uppercase" style={{ color: accentHex }}>Set New Password</div>
+              <h2 className="text-2xl font-semibold tracking-tight">Choose a new password</h2>
+            </div>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label className="block text-sm text-zinc-400 mb-1 tracking-wide">NEW PASSWORD</label>
+                <div className="relative">
+                  <input
+                    type={showPassword ? 'text' : 'password'}
+                    value={password}
+                    onChange={e => setPassword(e.target.value)}
+                    className="glass-input w-full rounded-2xl px-4 py-3 text-sm placeholder:text-zinc-600 border border-white/10 focus:border-white/40 outline-none transition-all pr-12"
+                    placeholder="Min 8 characters"
+                    required
+                    minLength={8}
+                    autoFocus
+                  />
+                  <button type="button" onClick={() => setShowPassword(!showPassword)} className="absolute right-4 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-white transition-colors" tabIndex={-1}>
+                    {showPassword ? (
+                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19m-6.72-1.07a3 3 0 11-4.24-4.24"/>
+                        <line x1="1" y1="1" x2="23" y2="23"/>
+                      </svg>
+                    ) : (
+                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+                        <circle cx="12" cy="12" r="3"/>
+                      </svg>
+                    )}
+                  </button>
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm text-zinc-400 mb-1 tracking-wide">CONFIRM PASSWORD</label>
+                <input
+                  type={showPassword ? 'text' : 'password'}
+                  value={confirm}
+                  onChange={e => setConfirm(e.target.value)}
+                  className="glass-input w-full rounded-2xl px-4 py-3 text-sm placeholder:text-zinc-600 border border-white/10 focus:border-white/40 outline-none transition-all"
+                  placeholder="Repeat password"
+                  required
+                />
+              </div>
+              {error && (
+                <div className="text-sm text-red-400 flex items-center gap-2 bg-red-950/40 border border-red-900/60 rounded-xl px-4 py-2">
+                  ⚠ {error}
+                </div>
+              )}
+              <button
+                type="submit"
+                disabled={loading}
+                className="glass-btn-green w-full py-3.5 rounded-2xl text-base font-semibold tracking-[0.5px] transition-all active:scale-[0.985] disabled:opacity-60 disabled:cursor-not-allowed"
+              >
+                {loading ? 'Updating…' : 'Update Password'}
+              </button>
+              <div className="text-center">
+                <a href="login" className="text-sm text-zinc-400 hover:text-white underline underline-offset-4 transition-colors">Back to sign in</a>
+              </div>
+            </form>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
 // ===== Auth pages =====
 function LoginPage() {
   const [email, setEmail] = useState(() => localStorage.getItem('lastEmail') || '')
@@ -467,9 +692,55 @@ function LoginPage() {
   const [showPassword, setShowPassword] = useState(false)
   const [focusedField, setFocusedField] = useState<string | null>(null)
   const [shockwaveActive] = useState(false)
+  const [showForgotPassword, setShowForgotPassword] = useState(false)
 
   const isReturningUser = !!localStorage.getItem('lastEmail')
   const loginAccentHex = getThemeAccentHex(localStorage.getItem('theme') || 'green')
+
+  const handleGoogleSignIn = () => {
+    if (!GOOGLE_CLIENT_ID) {
+      setError('Google Sign-In is not configured. Add VITE_GOOGLE_CLIENT_ID to your environment.')
+      return
+    }
+    const g = (window as any).google
+    if (!g?.accounts?.oauth2) {
+      setError('Google Sign-In library not loaded. Please refresh and try again.')
+      return
+    }
+    setError(null)
+    setLoading(true)
+    const client = g.accounts.oauth2.initTokenClient({
+      client_id: GOOGLE_CLIENT_ID,
+      scope: 'openid email profile',
+      callback: async (tokenResponse: any) => {
+        if (tokenResponse.error) {
+          setError('Google sign-in was cancelled or failed.')
+          setLoading(false)
+          return
+        }
+        try {
+          const res = await fetch(`${API_BASE}/api/auth/google`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ access_token: tokenResponse.access_token }),
+          })
+          const data = await res.json()
+          if (!res.ok) {
+            setError(data.error || 'Google sign-in failed')
+          } else {
+            localStorage.setItem('user', JSON.stringify(data))
+            localStorage.setItem('lastEmail', data.email)
+            window.location.href = '.'
+          }
+        } catch {
+          setError('Google sign-in failed. Please try again.')
+        } finally {
+          setLoading(false)
+        }
+      },
+    })
+    client.requestAccessToken()
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -559,6 +830,18 @@ function LoginPage() {
             )}
           </div>
 
+          {/* Demo callout */}
+          <div className="mb-4 flex items-start gap-2.5 px-3.5 py-2.5 rounded-xl border" style={{ background: `${loginAccentHex}12`, borderColor: `${loginAccentHex}30` }}>
+            <span className="text-base mt-0.5 shrink-0" style={{ color: loginAccentHex }}>✦</span>
+            <span className="text-xs text-zinc-400 leading-relaxed">
+              No account?{' '}
+              <a href="signup" className="font-medium transition-colors hover:opacity-80" style={{ color: loginAccentHex }}>
+                Create one free
+              </a>
+              {' '}— explore all features, no credit card required.
+            </span>
+          </div>
+
           <form onSubmit={handleSubmit} className="space-y-4">
             {/* Email */}
             <div>
@@ -630,9 +913,32 @@ function LoginPage() {
               {loading ? 'Signing in…' : 'Sign In'}
             </button>
 
+            {/* Divider */}
+            <div className="relative flex items-center py-1">
+              <div className="flex-1 border-t border-white/10" />
+              <span className="px-3 text-[11px] text-zinc-600">or</span>
+              <div className="flex-1 border-t border-white/10" />
+            </div>
+
+            {/* Google Sign-In */}
+            <button
+              type="button"
+              onClick={handleGoogleSignIn}
+              disabled={loading}
+              className="w-full py-3 rounded-2xl border border-white/15 bg-white/5 hover:bg-white/10 text-sm font-medium flex items-center justify-center gap-2.5 transition-all active:scale-[0.985] disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              <svg viewBox="0 0 24 24" className="w-4 h-4 shrink-0" xmlns="http://www.w3.org/2000/svg">
+                <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+              </svg>
+              Continue with Google
+            </button>
+
             {/* Links */}
             <div className="flex justify-between text-sm pt-1">
-              <a href="#" className="text-zinc-500 hover:text-white transition-colors">Forgot password?</a>
+              <button type="button" onClick={() => setShowForgotPassword(true)} className="text-zinc-500 hover:text-white transition-colors">Forgot password?</button>
               <a href="signup" className="text-zinc-400 hover:text-white underline underline-offset-4">Create account</a>
             </div>
           </form>
@@ -648,6 +954,14 @@ function LoginPage() {
       <div className="absolute bottom-6 right-0 p-4 text-[10px] text-zinc-600">
         © 2026 SwiftShift. All rights reserved.
       </div>
+
+      {/* Forgot password modal */}
+      {showForgotPassword && (
+        <ForgotPasswordModal
+          onClose={() => setShowForgotPassword(false)}
+          accentHex={loginAccentHex}
+        />
+      )}
     </div>
   )
 }
@@ -663,6 +977,52 @@ function SignupPage() {
   const [focusedField, setFocusedField] = useState<string | null>(null)
   const [shockwaveActive] = useState(false)
   const signupAccentHex = getThemeAccentHex(localStorage.getItem('theme') || 'green')
+
+  const handleGoogleSignUp = () => {
+    if (!GOOGLE_CLIENT_ID) {
+      setError('Google Sign-In is not configured. Add VITE_GOOGLE_CLIENT_ID to your environment.')
+      return
+    }
+    const g = (window as any).google
+    if (!g?.accounts?.oauth2) {
+      setError('Google Sign-In library not loaded. Please refresh and try again.')
+      return
+    }
+    setError(null)
+    setLoading(true)
+    const client = g.accounts.oauth2.initTokenClient({
+      client_id: GOOGLE_CLIENT_ID,
+      scope: 'openid email profile',
+      callback: async (tokenResponse: any) => {
+        if (tokenResponse.error) {
+          setError('Google sign-in was cancelled or failed.')
+          setLoading(false)
+          return
+        }
+        try {
+          const res = await fetch(`${API_BASE}/api/auth/google`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ access_token: tokenResponse.access_token }),
+          })
+          const data = await res.json()
+          if (!res.ok) {
+            setError(data.error || 'Google sign-in failed')
+          } else {
+            localStorage.setItem('user', JSON.stringify(data))
+            localStorage.setItem('lastEmail', data.email)
+            window.location.href = '.'
+          }
+        } catch {
+          setError('Google sign-in failed. Please try again.')
+        } finally {
+          setLoading(false)
+        }
+      },
+    })
+    client.requestAccessToken()
+  }
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError(null)
@@ -840,6 +1200,29 @@ function SignupPage() {
               {loading ? 'Creating account…' : 'Create Account'}
             </button>
 
+            {/* Divider */}
+            <div className="relative flex items-center py-1">
+              <div className="flex-1 border-t border-white/10" />
+              <span className="px-3 text-[11px] text-zinc-600">or</span>
+              <div className="flex-1 border-t border-white/10" />
+            </div>
+
+            {/* Google Sign-Up */}
+            <button
+              type="button"
+              onClick={handleGoogleSignUp}
+              disabled={loading}
+              className="w-full py-3 rounded-2xl border border-white/15 bg-white/5 hover:bg-white/10 text-sm font-medium flex items-center justify-center gap-2.5 transition-all active:scale-[0.985] disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              <svg viewBox="0 0 24 24" className="w-4 h-4 shrink-0" xmlns="http://www.w3.org/2000/svg">
+                <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+              </svg>
+              Continue with Google
+            </button>
+
             <div className="text-center text-sm pt-1">
               <a href="login" className="text-zinc-400 hover:text-white underline underline-offset-4">Already have an account?</a>
             </div>
@@ -862,15 +1245,22 @@ function SignupPage() {
 // ===== Main App (existing) =====
 export default function App() {
   const pathname = window.location.pathname
-  const userStr = localStorage.getItem('user')
-  const user = userStr ? JSON.parse(userStr) : null
+  let user: any = null
+  try {
+    const userStr = localStorage.getItem('user')
+    if (userStr) user = JSON.parse(userStr)
+  } catch {
+    localStorage.removeItem('user')
+  }
 
   // Route: auth pages (handle subpath deployments like /hackathon/preview/doesitworkday/)
   const isRoot = pathname === '/' || pathname.endsWith('/')
   const isLogin = pathname === '/login' || pathname.endsWith('/login')
   const isSignup = pathname === '/signup' || pathname.endsWith('/signup')
   const isAdmin = pathname === '/admin' || pathname.endsWith('/admin')
+  const isResetPassword = pathname === '/reset-password' || pathname.endsWith('/reset-password')
 
+  if (isResetPassword) return <ResetPasswordPage />
   if (isSignup) return <SignupPage />
 
   // Gate: nothing visible without login

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,8 @@ import { toast } from 'sonner'
 import { useTimesheet } from './hooks/useTimesheet'
 import { Rewards } from './components/Rewards'
 import { LootDrop } from './components/LootDrop'
+import { Tour } from './components/Tour'
+import { FeaturePreview } from './components/FeaturePreview'
 
 const API_BASE = (() => {
   const m = window.location.pathname.match(/^(\/hackathon\/preview\/[^/]+)/)
@@ -693,6 +695,7 @@ function LoginPage() {
   const [focusedField, setFocusedField] = useState<string | null>(null)
   const [shockwaveActive] = useState(false)
   const [showForgotPassword, setShowForgotPassword] = useState(false)
+  const [showFeaturePreview, setShowFeaturePreview] = useState(false)
 
   const isReturningUser = !!localStorage.getItem('lastEmail')
   const loginAccentHex = getThemeAccentHex(localStorage.getItem('theme') || 'green')
@@ -941,6 +944,17 @@ function LoginPage() {
               <button type="button" onClick={() => setShowForgotPassword(true)} className="text-zinc-500 hover:text-white transition-colors">Forgot password?</button>
               <a href="signup" className="text-zinc-400 hover:text-white underline underline-offset-4">Create account</a>
             </div>
+
+            {/* Tour button */}
+            <div className="text-center mt-1">
+              <button
+                type="button"
+                onClick={() => setShowFeaturePreview(true)}
+                className="text-xs text-zinc-600 hover:text-zinc-400 transition-colors"
+              >
+                Explore features →
+              </button>
+            </div>
           </form>
 
           {/* Footer hint */}
@@ -962,6 +976,13 @@ function LoginPage() {
           accentHex={loginAccentHex}
         />
       )}
+
+      {showFeaturePreview && (
+        <FeaturePreview
+          onClose={() => setShowFeaturePreview(false)}
+          accentHex={loginAccentHex}
+        />
+      )}
     </div>
   )
 }
@@ -976,6 +997,7 @@ function SignupPage() {
   const [showPassword, setShowPassword] = useState(false)
   const [focusedField, setFocusedField] = useState<string | null>(null)
   const [shockwaveActive] = useState(false)
+  const [showFeaturePreview, setShowFeaturePreview] = useState(false)
   const signupAccentHex = getThemeAccentHex(localStorage.getItem('theme') || 'green')
 
   const handleGoogleSignUp = () => {
@@ -1039,6 +1061,7 @@ function SignupPage() {
       } else {
         localStorage.setItem('user', JSON.stringify(data))
         localStorage.setItem('lastEmail', email)
+        localStorage.setItem('swiftshift-tour-pending', '1')
         window.location.href = '.'
       }
     } catch {
@@ -1226,6 +1249,17 @@ function SignupPage() {
             <div className="text-center text-sm pt-1">
               <a href="login" className="text-zinc-400 hover:text-white underline underline-offset-4">Already have an account?</a>
             </div>
+
+            {/* Tour button */}
+            <div className="text-center mt-1">
+              <button
+                type="button"
+                onClick={() => setShowFeaturePreview(true)}
+                className="text-xs text-zinc-600 hover:text-zinc-400 transition-colors"
+              >
+                Explore features →
+              </button>
+            </div>
           </form>
 
           <div className="mt-6 pt-5 border-t border-white/10 text-center text-[10px] text-zinc-500 tracking-[1px]">
@@ -1238,6 +1272,13 @@ function SignupPage() {
       <div className="absolute bottom-6 right-0 p-4 text-[10px] text-zinc-600">
         © 2026 SwiftShift. All rights reserved.
       </div>
+
+      {showFeaturePreview && (
+        <FeaturePreview
+          onClose={() => setShowFeaturePreview(false)}
+          accentHex={signupAccentHex}
+        />
+      )}
     </div>
   )
 }
@@ -1279,6 +1320,7 @@ export default function App() {
 
   // Main app
   const [activeView, setActiveView] = useState<View>('clock')
+  const [showTour, setShowTour] = useState(() => localStorage.getItem('swiftshift-tour-pending') === '1')
   const [chatMessage, setChatMessage] = useState('')
   const [chatLoading, setChatLoading] = useState(false)
   const [chatHistory, setChatHistory] = useState<Array<{ role: 'user' | 'assistant'; content: string }>>([])
@@ -1393,6 +1435,13 @@ export default function App() {
   }
 
   useTimesheet() // runs side effects (seeding)
+
+  // Clear tour-pending flag once tour is displayed
+  useEffect(() => {
+    if (showTour) {
+      localStorage.removeItem('swiftshift-tour-pending')
+    }
+  }, [showTour])
 
   // Handle /admin URL
   useEffect(() => {
@@ -1757,6 +1806,12 @@ export default function App() {
                 className="w-full text-left px-4 py-2 text-sm hover:bg-white/5 rounded-t-xl"
               >
                 Profile
+              </button>
+              <button
+                onClick={() => setShowTour(true)}
+                className="w-full text-left px-4 py-2 text-sm hover:bg-white/5"
+              >
+                Take tour
               </button>
               <button
                 className="w-full text-left px-4 py-2 text-sm hover:bg-white/5 text-zinc-400 cursor-not-allowed"
@@ -3264,6 +3319,17 @@ export default function App() {
             </div>
           )}
         </main>
+
+        {/* Guided tour modal */}
+        {showTour && (
+          <Tour
+            onClose={() => {
+              setShowTour(false)
+              localStorage.setItem('swiftshift-tour-seen', '1')
+            }}
+            accentHex={themeAccentHex}
+          />
+        )}
 
         {/* Clock-out Loot Drop modal */}
         <LootDrop

--- a/frontend/src/components/FeaturePreview.tsx
+++ b/frontend/src/components/FeaturePreview.tsx
@@ -1,0 +1,82 @@
+import { motion } from 'framer-motion'
+
+const FEATURES = [
+  { icon: '⏱', title: 'Time Clock', desc: 'Clock in/out with one click. Real-time earnings display and break tracking.' },
+  { icon: '📋', title: 'Timesheet', desc: 'View, edit, and submit all your time entries. Track hours by project and task.' },
+  { icon: '🏆', title: 'Rewards', desc: 'Gamified daily streaks and real-time earnings Odometer for every second worked.' },
+  { icon: '💳', title: 'Payroll & Reports', desc: 'Full pay details, analytics dashboards, and exportable reports.' },
+  { icon: '💰', title: 'AI Tax Filing', desc: 'Upload your W-2 or 1099 and Swifty AI fills out your 1040 instantly.' },
+  { icon: '🤖', title: 'AI Assistant', desc: 'Chat with Swifty for instant HR answers, leave policy info, and more.' },
+  { icon: '⚡', title: 'InstaApply', desc: 'Upload your resume once — get matched to jobs and apply in seconds.' },
+  { icon: '🛡', title: 'Insurance & Benefits', desc: 'Browse and manage your health, dental, and vision benefits.' },
+  { icon: '📊', title: 'Org Chart', desc: 'Visualize your entire company structure at a glance.' },
+]
+
+interface FeaturePreviewProps {
+  onClose: () => void
+  accentHex?: string
+}
+
+export function FeaturePreview({ onClose, accentHex = '#D7FE51' }: FeaturePreviewProps) {
+  return (
+    <div
+      className="fixed inset-0 z-[300] flex items-center justify-center bg-black/80 backdrop-blur-sm p-4"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95, y: 20 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.95, y: 10 }}
+        transition={{ duration: 0.25 }}
+        className="glass w-full max-w-[560px] rounded-3xl border border-white/10 overflow-hidden"
+        style={{ boxShadow: `0 0 60px -20px ${accentHex}25, 0 28px 72px -14px rgba(0,0,0,0.85)` }}
+      >
+        {/* Header */}
+        <div className="px-8 pt-8 pb-4">
+          <div className="flex items-center justify-between mb-2">
+            <div className="text-xs tracking-[3px] uppercase" style={{ color: accentHex }}>
+              Product Tour
+            </div>
+            <button
+              onClick={onClose}
+              className="text-zinc-500 hover:text-white transition-colors text-2xl leading-none w-7 h-7 flex items-center justify-center rounded-lg hover:bg-white/5"
+              aria-label="Close feature preview"
+            >
+              ×
+            </button>
+          </div>
+          <h2 className="text-2xl font-semibold tracking-tight mb-1">Everything you need.</h2>
+          <p className="text-zinc-500 text-sm">SwiftShift is your all-in-one AI-powered HR platform.</p>
+        </div>
+
+        {/* Feature grid */}
+        <div className="px-8 pb-6 max-h-[50vh] overflow-y-auto">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
+            {FEATURES.map((f) => (
+              <div
+                key={f.title}
+                className="rounded-2xl border border-white/8 p-4 hover:border-white/15 transition-colors"
+                style={{ background: 'rgba(255,255,255,0.025)' }}
+              >
+                <div className="text-2xl mb-2 leading-none">{f.icon}</div>
+                <div className="font-semibold text-sm mb-1 text-white">{f.title}</div>
+                <div className="text-xs text-zinc-500 leading-relaxed">{f.desc}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="px-8 pb-8 pt-2 border-t border-white/8">
+          <button
+            onClick={onClose}
+            className="w-full py-2.5 rounded-xl text-sm font-semibold transition-all hover:opacity-90 active:scale-[0.98]"
+            style={{ background: accentHex, color: accentHex === '#D7FE51' || accentHex === '#E5E7EB' || accentHex === '#51FEFE' || accentHex === '#FE51D7' ? '#000' : '#fff' }}
+          >
+            Got it — let's go
+          </button>
+        </div>
+      </motion.div>
+    </div>
+  )
+}

--- a/frontend/src/components/QuickAdd.tsx
+++ b/frontend/src/components/QuickAdd.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { toast } from 'sonner'
+import confetti from 'canvas-confetti'
 import { TimeEntry } from '../types'
 import { format } from 'date-fns'
 
@@ -69,9 +70,10 @@ export function QuickAdd({ onAdd, disabled }: QuickAddProps) {
     }
 
     onAdd(form)
-    toast.success('Time entry added', { 
-      description: `${form.project} • ${form.task}` 
+    toast.success('Time entry added! ✅', {
+      description: `${form.project} • ${form.task}`
     })
+    confetti({ particleCount: 60, spread: 55, origin: { y: 0.65 }, ticks: 50 })
 
     // Reset form but keep date/project/task
     setForm(prev => ({

--- a/frontend/src/components/Rewards.tsx
+++ b/frontend/src/components/Rewards.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState, useRef, useCallback } from 'react'
 import confetti from 'canvas-confetti'
+import { motion } from 'framer-motion'
+import { Odometer } from './Odometer'
 
 interface RewardsProps {
   totalHours: number
@@ -10,27 +12,24 @@ interface RewardsProps {
   onFocus?: () => void
 }
 
-// Compute hourly rate from user: if salary set (salaried), hourly = salary/2080, else use pay (default $65)
 function computeHourlyRate(user: any): number {
   const salary = Number(user?.salary) || 0
-  if (salary > 0) {
-    return salary / 2080
-  }
+  if (salary > 0) return salary / 2080
   const pay = Number(user?.pay)
   return pay > 0 ? pay : 65
 }
 
+const LEVEL_NAMES = ['Rookie', 'Associate', 'Pro', 'Senior', 'Expert', 'Elite', 'Master', 'Legend']
+
 export function Rewards({ totalHours, elapsedSeconds, isClockedIn, theme = 'green', user, onFocus }: RewardsProps) {
   const [hourlyRate, setHourlyRate] = useState(() => computeHourlyRate(user))
-  const [ptoAccrualRate, setPtoAccrualRate] = useState(1 / 30) // 1 hour per 30 hours worked
+  const [ptoAccrualRate, setPtoAccrualRate] = useState(1 / 30)
   const [hasFiredConfetti, setHasFiredConfetti] = useState(false)
+  const [streak, setStreak] = useState(0)
   const prevCentsRef = useRef(0)
   const containerRef = useRef<HTMLDivElement>(null)
 
-  const liveTodayEarnings = isClockedIn
-    ? (elapsedSeconds / 3600) * hourlyRate
-    : 0
-
+  const liveTodayEarnings = isClockedIn ? (elapsedSeconds / 3600) * hourlyRate : 0
   const earnedToday = liveTodayEarnings
   const totalEarnings = totalHours * hourlyRate
   const accruedPTO = totalHours * ptoAccrualRate
@@ -44,9 +43,29 @@ export function Rewards({ totalHours, elapsedSeconds, isClockedIn, theme = 'gree
     pink: '#FE51D7',
     purple: '#9B51FE',
   }
-  const confettiColor = isOvertime ? '#FFAA00' : themeColors[theme]
+  const accentColor = themeColors[theme]
+  const confettiColor = isOvertime ? '#FFAA00' : accentColor
 
-  // Paycheck date helpers: 2nd Friday and last Friday of each month
+  // Gamification calculations
+  const dailyGoalDollars = hourlyRate * 8
+  const dailyGoalProgress = Math.min(100, earnedToday > 0 ? (earnedToday / dailyGoalDollars) * 100 : 0)
+
+  const totalXP = Math.floor(totalHours * 100)
+  const level = Math.floor(totalXP / 500) + 1
+  const levelName = LEVEL_NAMES[Math.min(level - 1, LEVEL_NAMES.length - 1)]
+  const xpForCurrentLevel = (level - 1) * 500
+  const xpProgress = Math.min(100, ((totalXP - xpForCurrentLevel) / 500) * 100)
+
+  const achievements = [
+    { id: 'first_shift', label: 'First Shift', icon: '⚡', desc: 'Clock in for the first time', unlocked: totalHours > 0 || isClockedIn },
+    { id: 'century', label: 'Century Club', icon: '💯', desc: 'Earn $100 in a day', unlocked: earnedToday >= 100 },
+    { id: 'overtime', label: 'Overtime Warrior', icon: '🔥', desc: 'Work over 9 hours', unlocked: totalHours > 9 },
+    { id: 'streak_3', label: 'On a Roll', icon: '🎯', desc: 'Work 3 days in a row', unlocked: streak >= 3 },
+    { id: 'high_earner', label: 'High Earner', icon: '💎', desc: 'Earn $500 in a week', unlocked: totalEarnings >= 500 },
+    { id: 'pto_master', label: 'PTO Hoarder', icon: '🏖️', desc: 'Accrue 1 hour of PTO', unlocked: accruedPTO >= 1 },
+  ]
+
+  // Paycheck helpers
   const getPaycheckDates = (year: number, month: number) => {
     let day = 1
     while (new Date(year, month, day).getDay() !== 5) day++
@@ -54,98 +73,98 @@ export function Rewards({ totalHours, elapsedSeconds, isClockedIn, theme = 'gree
     const lastDay = new Date(year, month + 1, 0).getDate()
     let lastFridayDate = lastDay
     while (new Date(year, month, lastFridayDate).getDay() !== 5) lastFridayDate--
-    const lastFriday = new Date(year, month, lastFridayDate)
-    return { secondFriday, lastFriday }
+    return { secondFriday, lastFriday: new Date(year, month, lastFridayDate) }
   }
 
   const getNextPaycheck = () => {
     const today = new Date()
     today.setHours(0, 0, 0, 0)
-    const year = today.getFullYear()
-    const month = today.getMonth()
-    const { secondFriday, lastFriday } = getPaycheckDates(year, month)
-
+    const { secondFriday, lastFriday } = getPaycheckDates(today.getFullYear(), today.getMonth())
     if (today <= secondFriday) return secondFriday
     if (today <= lastFriday) return lastFriday
-    const { secondFriday: nextSecond } = getPaycheckDates(year, month + 1)
-    return nextSecond
+    return getPaycheckDates(today.getFullYear(), today.getMonth() + 1).secondFriday
   }
 
   const daysUntilNextPaycheck = () => {
     const next = getNextPaycheck()
     const today = new Date()
     today.setHours(0, 0, 0, 0)
-    const diff = Math.ceil((next.getTime() - today.getTime()) / (1000 * 60 * 60 * 24))
-    return Math.max(0, diff)
+    return Math.max(0, Math.ceil((next.getTime() - today.getTime()) / 86400000))
   }
 
-  const estimatedPaycheck = totalEarnings
+  const daysUntil = daysUntilNextPaycheck()
+  const paycheckProgress = Math.min(100, ((14 - daysUntil) / 14) * 100)
 
-  // Haptic ticker: fire vibration on each cent increment
+  // Streak tracking via localStorage
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem('swiftshift-streak')
+      if (stored) {
+        const { count, lastDate } = JSON.parse(stored)
+        const today = new Date().toDateString()
+        const yesterday = new Date(Date.now() - 86400000).toDateString()
+        if (lastDate === today || lastDate === yesterday) setStreak(count)
+      }
+    } catch {}
+  }, [])
+
+  useEffect(() => {
+    if (!isClockedIn) return
+    try {
+      const today = new Date().toDateString()
+      const stored = localStorage.getItem('swiftshift-streak')
+      if (!stored) {
+        localStorage.setItem('swiftshift-streak', JSON.stringify({ count: 1, lastDate: today }))
+        setStreak(1)
+        return
+      }
+      const { count, lastDate } = JSON.parse(stored)
+      if (lastDate === today) return
+      const yesterday = new Date(Date.now() - 86400000).toDateString()
+      const newCount = lastDate === yesterday ? count + 1 : 1
+      localStorage.setItem('swiftshift-streak', JSON.stringify({ count: newCount, lastDate: today }))
+      setStreak(newCount)
+    } catch {}
+  }, [isClockedIn])
+
+  // Haptic on cent increment
   const triggerHaptic = useCallback((currentCents: number) => {
     if (currentCents !== prevCentsRef.current && 'vibrate' in navigator) {
-      try {
-        navigator.vibrate(10)
-      } catch {
-        // Ignore if not supported
-      }
+      try { navigator.vibrate(10) } catch {}
     }
     prevCentsRef.current = currentCents
   }, [])
 
   useEffect(() => {
     if (!isClockedIn) return
-    const cents = Math.floor(earnedToday * 100) % 100
-    triggerHaptic(cents)
+    triggerHaptic(Math.floor(earnedToday * 100) % 100)
   }, [earnedToday, isClockedIn, triggerHaptic])
 
-  // Neon green confetti from bottom when rewards tab focuses
+  // Confetti on tab focus
   useEffect(() => {
     if (onFocus && !hasFiredConfetti) {
       const timer = setTimeout(() => {
-        confetti({
-          particleCount: 180,
-          spread: 90,
-          origin: { x: 0.5, y: 0.95 },
-          colors: [confettiColor, '#39FF14', '#00CC00'],
-        })
-        setTimeout(() => {
-          confetti({
-            particleCount: 120,
-            spread: 70,
-            angle: 75,
-            origin: { x: 0.3, y: 0.9 },
-            colors: [confettiColor, '#39FF14'],
-          })
-        }, 120)
-        setTimeout(() => {
-          confetti({
-            particleCount: 120,
-            spread: 70,
-            angle: 105,
-            origin: { x: 0.7, y: 0.9 },
-            colors: [confettiColor, '#00CC00'],
-          })
-        }, 240)
+        confetti({ particleCount: 180, spread: 90, origin: { x: 0.5, y: 0.95 }, colors: [confettiColor, '#39FF14', '#00CC00'] })
+        setTimeout(() => confetti({ particleCount: 120, spread: 70, angle: 75, origin: { x: 0.3, y: 0.9 }, colors: [confettiColor, '#39FF14'] }), 120)
+        setTimeout(() => confetti({ particleCount: 120, spread: 70, angle: 105, origin: { x: 0.7, y: 0.9 }, colors: [confettiColor, '#00CC00'] }), 240)
         setHasFiredConfetti(true)
       }, 80)
       return () => clearTimeout(timer)
     }
-  }, [onFocus, hasFiredConfetti])
+  }, [onFocus, hasFiredConfetti, confettiColor])
 
-  useEffect(() => {
-    return () => setHasFiredConfetti(false)
-  }, [])
+  useEffect(() => { return () => setHasFiredConfetti(false) }, [])
 
   return (
-    <div ref={containerRef} className="max-w-[1200px] mx-auto">
+    <div ref={containerRef} className="max-w-[1200px] mx-auto space-y-4">
+
+      {/* ═══════════════════════════════════════════
+          TOP MODULE — Live Earnings Machine
+          ═══════════════════════════════════════════ */}
       <div className="glass rounded-3xl p-6">
         {/* Header */}
         <div className="flex items-center justify-between mb-6">
-          <div>
-            <div className="text-2xl font-semibold neon-green">Rewards</div>
-          </div>
-
+          <div className="text-2xl font-semibold neon-green">Rewards</div>
           <div className="flex items-center gap-4 text-sm">
             <div className="flex items-center gap-2">
               <span className="text-zinc-500">Rate:</span>
@@ -184,26 +203,298 @@ export function Rewards({ totalHours, elapsedSeconds, isClockedIn, theme = 'gree
 
         {/* Three modules side-by-side */}
         <div className="grid grid-cols-3 gap-4">
-          <div className="glass rounded-3xl p-6 flex-1">
-            <div className="text-sm uppercase tracking-[2px] text-white mb-2">Today's Earnings</div>
-            <div className="text-4xl font-medium mb-1.5 neon-green">{isClockedIn ? `$${earnedToday.toFixed(2)}` : 'CLOCK IN'}</div>
-            <div className="text-sm text-zinc-400 mb-3">Real time earnings</div>
+
+          {/* ── SLOT MACHINE EARNINGS ── */}
+          <div className="glass rounded-3xl p-6 relative overflow-hidden">
+            <div
+              className="absolute inset-0 pointer-events-none"
+              style={{ background: `radial-gradient(ellipse at 50% 0%, ${accentColor}1A 0%, transparent 65%)` }}
+            />
+            <div className="text-xs uppercase tracking-[3px] text-zinc-400 mb-3 relative">Today's Earnings</div>
+
+            {isClockedIn ? (
+              <div className="relative">
+                {/* Slot machine bezel */}
+                <div
+                  className="relative inline-block mb-2"
+                  style={{
+                    background: 'rgba(0,0,0,0.92)',
+                    borderRadius: '14px',
+                    padding: '10px 16px 10px 12px',
+                    border: `1px solid ${accentColor}35`,
+                    boxShadow: `0 0 28px ${accentColor}22, inset 0 2px 0 rgba(255,255,255,0.08), inset 0 -2px 0 rgba(0,0,0,0.6)`,
+                  }}
+                >
+                  {/* Scanning gloss line */}
+                  <motion.div
+                    className="absolute inset-x-0 h-px pointer-events-none"
+                    style={{
+                      background: `linear-gradient(90deg, transparent 0%, ${accentColor}55 50%, transparent 100%)`,
+                      top: '52%',
+                    }}
+                    animate={{ opacity: [0, 0.8, 0] }}
+                    transition={{ repeat: Infinity, duration: 2.8, ease: 'easeInOut' }}
+                  />
+                  <Odometer
+                    value={earnedToday}
+                    format="currency"
+                    className="text-4xl"
+                    speed={isOvertime ? 1.5 : 1}
+                    color={isOvertime ? '#FFAA00' : accentColor}
+                  />
+                </div>
+
+                {/* Live / Overtime badge */}
+                <div className="flex items-center gap-1.5">
+                  <motion.div
+                    className="w-1.5 h-1.5 rounded-full bg-green-400"
+                    animate={{ opacity: [1, 0.25, 1] }}
+                    transition={{ repeat: Infinity, duration: 1.2 }}
+                  />
+                  <span className="text-[10px] uppercase tracking-widest text-zinc-500">
+                    {isOvertime ? 'Overtime ×1.5' : 'Live'}
+                  </span>
+                </div>
+              </div>
+            ) : (
+              <div>
+                <div className="text-3xl font-light text-zinc-700 tracking-widest mb-1 font-mono">— — —</div>
+                <div className="text-xs text-zinc-600">Clock in to start earning</div>
+              </div>
+            )}
+
+            <div className="text-xs text-zinc-500 mt-2">Real time earnings</div>
           </div>
-          <div className="glass rounded-3xl p-6 flex-1">
-            <div className="text-sm uppercase tracking-[2px] text-white mb-2">Today's Accrued PTO</div>
-            <div className="text-4xl font-medium mb-1.5 neon-green">{isClockedIn ? `${accruedPTO.toFixed(2)} hrs` : 'CLOCK IN'}</div>
-            <div className="text-sm text-zinc-400 mb-3">Real Time PTO Earned</div>
+
+          {/* ── PTO MODULE ── */}
+          <div className="glass rounded-3xl p-6 relative overflow-hidden">
+            <div
+              className="absolute inset-0 pointer-events-none"
+              style={{ background: 'radial-gradient(ellipse at 50% 0%, rgba(81,254,254,0.07) 0%, transparent 65%)' }}
+            />
+            <div className="text-xs uppercase tracking-[3px] text-zinc-400 mb-3 relative">Today's Accrued PTO</div>
+
+            {isClockedIn ? (
+              <div className="relative">
+                <div
+                  className="relative inline-flex items-baseline mb-2"
+                  style={{
+                    background: 'rgba(0,0,0,0.92)',
+                    borderRadius: '14px',
+                    padding: '10px 16px 10px 12px',
+                    border: '1px solid rgba(81,254,254,0.2)',
+                    boxShadow: 'inset 0 2px 0 rgba(255,255,255,0.06)',
+                  }}
+                >
+                  <Odometer value={accruedPTO} format="decimal" className="text-4xl" color="#51FEFE" />
+                  <span className="text-sm text-zinc-400 ml-2 mb-0.5">hrs</span>
+                </div>
+              </div>
+            ) : (
+              <div className="text-3xl font-light text-zinc-700 tracking-widest font-mono">— — —</div>
+            )}
+
+            <div className="text-xs text-zinc-500 mt-2">Real time PTO accrual</div>
           </div>
-          <div className="glass rounded-3xl p-6 flex-1">
-            <div className="text-sm uppercase tracking-[2px] text-white mb-2">Estimated Next Paycheck</div>
-            <div className="text-4xl font-medium mb-1.5 neon-green">${estimatedPaycheck.toFixed(0)}</div>
-            <div className="text-sm text-zinc-400 mb-3">{daysUntilNextPaycheck()} days until next paycheck</div>
+
+          {/* ── PAYCHECK MODULE ── */}
+          <div className="glass rounded-3xl p-6 relative overflow-hidden">
+            <div className="text-xs uppercase tracking-[3px] text-zinc-400 mb-3">Estimated Next Paycheck</div>
+            <div className="text-4xl font-medium mb-2 neon-green">${Math.round(totalEarnings).toLocaleString()}</div>
+            <div className="text-xs text-zinc-500 mb-3">{daysUntil} days away</div>
+            <div className="crystal-progress">
+              <div
+                className="h-full rounded-full transition-all duration-1000"
+                style={{
+                  width: `${paycheckProgress}%`,
+                  background: `linear-gradient(90deg, ${accentColor}70, ${accentColor})`,
+                }}
+              />
+            </div>
+            <div className="text-[10px] text-zinc-600 mt-1.5 text-right">{Math.round(paycheckProgress)}% of pay cycle</div>
+          </div>
+        </div>
+      </div>
+
+      {/* ═══════════════════════════════════════════
+          DAILY MISSION
+          ═══════════════════════════════════════════ */}
+      <div className="glass rounded-3xl p-6">
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <div className="text-xs uppercase tracking-[2px] text-zinc-400">Daily Mission</div>
+            <div className="text-lg font-semibold neon-green mt-0.5">
+              Earn ${dailyGoalDollars.toFixed(0)} today
+            </div>
+          </div>
+          <div className="text-right">
+            <div
+              className="text-3xl font-bold tabular-nums"
+              style={{ color: dailyGoalProgress >= 100 ? accentColor : 'white' }}
+            >
+              {Math.round(dailyGoalProgress)}%
+            </div>
+            <div className="text-xs text-zinc-500">complete</div>
           </div>
         </div>
 
-        <div className="text-center text-xs text-zinc-500 pt-6">
-          SwiftShift - Instant gratification for your hard work.
+        <div className="crystal-progress" style={{ height: '10px' }}>
+          <motion.div
+            className="h-full rounded-full"
+            style={{ background: `linear-gradient(90deg, ${accentColor}70, ${accentColor})` }}
+            initial={{ width: 0 }}
+            animate={{ width: `${dailyGoalProgress}%` }}
+            transition={{ duration: 1.2, ease: 'easeOut' }}
+          />
         </div>
+
+        <div className="flex justify-between text-xs mt-2">
+          <span className="text-zinc-600">$0</span>
+          <span className="font-semibold" style={{ color: accentColor }}>${earnedToday.toFixed(2)}</span>
+          <span className="text-zinc-600">${dailyGoalDollars.toFixed(0)}</span>
+        </div>
+
+        {dailyGoalProgress >= 100 && (
+          <motion.div
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="mt-3 text-center text-xs font-semibold tracking-[3px] uppercase"
+            style={{ color: accentColor }}
+          >
+            Daily goal complete — great work
+          </motion.div>
+        )}
+      </div>
+
+      {/* ═══════════════════════════════════════════
+          STATS ROW: Streak + Level/XP + Hours
+          ═══════════════════════════════════════════ */}
+      <div className="grid grid-cols-3 gap-4">
+
+        {/* Work Streak */}
+        <div className="glass rounded-3xl p-6 text-center flex flex-col items-center justify-center">
+          <div className="text-xs uppercase tracking-[2px] text-zinc-400 mb-2">Work Streak</div>
+          <div className="text-4xl mb-1 select-none">🔥</div>
+          <div className="text-4xl font-bold neon-green tabular-nums">{streak}</div>
+          <div className="text-xs text-zinc-500 mt-1.5">
+            {streak === 0
+              ? 'Clock in to start'
+              : streak === 1
+              ? 'Day one — keep going!'
+              : `${streak} days in a row`}
+          </div>
+        </div>
+
+        {/* Level & XP */}
+        <div className="glass rounded-3xl p-6 text-center">
+          <div className="text-xs uppercase tracking-[2px] text-zinc-400 mb-1">Level {level}</div>
+          <div className="text-2xl font-bold neon-green">{levelName}</div>
+          <div className="mt-4 crystal-progress">
+            <div
+              className="h-full rounded-full transition-all duration-700"
+              style={{
+                width: `${xpProgress}%`,
+                background: `linear-gradient(90deg, ${accentColor}70, ${accentColor})`,
+              }}
+            />
+          </div>
+          <div className="text-xs text-zinc-500 mt-2">{totalXP} / {level * 500} XP</div>
+          <div className="text-[10px] text-zinc-600 mt-0.5">100 XP per hour worked</div>
+        </div>
+
+        {/* Hours Today */}
+        <div className="glass rounded-3xl p-6 text-center">
+          <div className="text-xs uppercase tracking-[2px] text-zinc-400 mb-2">Hours Today</div>
+          <div className="text-4xl font-bold neon-green tabular-nums">{totalHours.toFixed(1)}</div>
+          <div className="text-xs text-zinc-500 mt-1">
+            {isOvertime ? 'Overtime active' : isClockedIn ? 'Currently clocked in' : 'Clocked out'}
+          </div>
+          <div className="mt-3 crystal-progress">
+            <div
+              className="h-full rounded-full transition-all duration-700"
+              style={{
+                width: `${Math.min(100, (totalHours / 8) * 100)}%`,
+                background: isOvertime
+                  ? 'linear-gradient(90deg, #FFAA0070, #FFAA00)'
+                  : `linear-gradient(90deg, ${accentColor}70, ${accentColor})`,
+              }}
+            />
+          </div>
+          <div className="text-xs text-zinc-500 mt-1.5">
+            {Math.round(Math.min(100, (totalHours / 8) * 100))}% of 8-hour day
+          </div>
+        </div>
+      </div>
+
+      {/* ═══════════════════════════════════════════
+          ACHIEVEMENTS
+          ═══════════════════════════════════════════ */}
+      <div className="glass rounded-3xl p-6">
+        <div className="flex items-center justify-between mb-4">
+          <div className="text-xs uppercase tracking-[2px] text-zinc-400">Achievements</div>
+          <div className="text-xs text-zinc-500">
+            {achievements.filter(a => a.unlocked).length} / {achievements.length} unlocked
+          </div>
+        </div>
+
+        <div className="grid grid-cols-3 gap-3">
+          {achievements.map((ach, i) => (
+            <motion.div
+              key={ach.id}
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: ach.unlocked ? 1 : 0.35, y: 0 }}
+              transition={{ delay: i * 0.07, duration: 0.4 }}
+              className={`glass rounded-2xl p-4 transition-all duration-500 ${!ach.unlocked ? 'grayscale' : ''}`}
+              style={
+                ach.unlocked
+                  ? {
+                      boxShadow: `0 0 18px ${accentColor}18, inset 0 1px 0 rgba(255,255,255,0.08)`,
+                      borderColor: `${accentColor}22`,
+                    }
+                  : {}
+              }
+            >
+              <div className="text-2xl mb-2 select-none">{ach.icon}</div>
+              <div className="text-sm font-semibold neon-green leading-tight">{ach.label}</div>
+              <div className="text-xs text-zinc-500 mt-1 leading-snug">{ach.desc}</div>
+              {ach.unlocked && (
+                <div
+                  className="text-[10px] mt-2 font-semibold tracking-[2px] uppercase"
+                  style={{ color: accentColor }}
+                >
+                  Unlocked
+                </div>
+              )}
+            </motion.div>
+          ))}
+        </div>
+      </div>
+
+      {/* ═══════════════════════════════════════════
+          PTO VAULT
+          ═══════════════════════════════════════════ */}
+      <div className="glass rounded-3xl p-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="text-xs uppercase tracking-[2px] text-zinc-400 mb-1">PTO Vault</div>
+            <div className="flex items-baseline gap-2">
+              <span className="text-3xl font-bold neon-green tabular-nums">{accruedPTO.toFixed(3)}</span>
+              <span className="text-lg text-zinc-400">hrs</span>
+            </div>
+            <div className="text-xs text-zinc-500 mt-1">
+              Accruing 1 hr per {(1 / ptoAccrualRate).toFixed(0)} hrs worked
+            </div>
+          </div>
+          <div className="text-right">
+            <div className="text-xs text-zinc-500 mb-1">Projected annual PTO</div>
+            <div className="text-2xl font-semibold neon-green">{(2080 * ptoAccrualRate).toFixed(1)} hrs</div>
+            <div className="text-xs text-zinc-600 mt-0.5">{(2080 * ptoAccrualRate / 8).toFixed(1)} days / year</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="text-center text-xs text-zinc-500 pt-2 pb-4">
+        SwiftShift — Instant gratification for your hard work.
       </div>
     </div>
   )

--- a/frontend/src/components/Tour.tsx
+++ b/frontend/src/components/Tour.tsx
@@ -1,0 +1,174 @@
+import { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+
+interface TourStep {
+  icon: string
+  title: string
+  desc: string
+}
+
+const TOUR_STEPS: TourStep[] = [
+  {
+    icon: '👋',
+    title: 'Welcome to SwiftShift!',
+    desc: "You're in. Let's take a 60-second tour of the key features so you can hit the ground running.",
+  },
+  {
+    icon: '⏱',
+    title: 'Time Clock',
+    desc: 'Clock in and out with one click. Your earnings update in real time — every second counts. Track breaks too.',
+  },
+  {
+    icon: '📋',
+    title: 'Timesheet',
+    desc: 'All your time entries in one place. Add, edit, and submit your weekly timesheet with ease.',
+  },
+  {
+    icon: '🏆',
+    title: 'Rewards',
+    desc: 'Stay consistent and earn streak rewards. Watch your real-time earnings climb on the Odometer.',
+  },
+  {
+    icon: '💳',
+    title: 'Payroll & Reports',
+    desc: 'View pay details, export reports, and track your analytics — all in one dashboard.',
+  },
+  {
+    icon: '💰',
+    title: 'AI Tax Filing — Swifty',
+    desc: 'Upload your W-2 or 1099 and Swifty fills out your Form 1040 instantly. No accountant needed.',
+  },
+  {
+    icon: '🤖',
+    title: 'AI Assistant — Swifty',
+    desc: 'Ask Swifty anything — leave policies, HR questions, company info. Instant, intelligent answers.',
+  },
+  {
+    icon: '⚡',
+    title: 'InstaApply',
+    desc: 'Upload your resume once. SwiftShift matches you to jobs and applies in seconds.',
+  },
+  {
+    icon: '✅',
+    title: "You're all set!",
+    desc: "That covers the highlights. Start by clocking in — your first session is just one click away.",
+  },
+]
+
+interface TourProps {
+  onClose: () => void
+  accentHex?: string
+}
+
+export function Tour({ onClose, accentHex = '#D7FE51' }: TourProps) {
+  const [step, setStep] = useState(0)
+  const current = TOUR_STEPS[step]
+  const isLast = step === TOUR_STEPS.length - 1
+  const isDark = accentHex === '#D7FE51' || accentHex === '#E5E7EB' || accentHex === '#51FEFE' || accentHex === '#FE51D7'
+
+  const next = () => {
+    if (isLast) onClose()
+    else setStep(s => s + 1)
+  }
+
+  const prev = () => {
+    if (step > 0) setStep(s => s - 1)
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[300] flex items-center justify-center bg-black/75 backdrop-blur-sm"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={step}
+          initial={{ opacity: 0, y: 20, scale: 0.97 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: -10, scale: 0.97 }}
+          transition={{ duration: 0.22, ease: 'easeOut' }}
+          className="glass w-full max-w-[420px] rounded-3xl p-8 border border-white/10 mx-4"
+          style={{ boxShadow: `0 0 80px -20px ${accentHex}35, 0 28px 72px -14px rgba(0,0,0,0.85)` }}
+        >
+          {/* Progress bar */}
+          <div className="h-1 rounded-full bg-white/10 mb-6 overflow-hidden">
+            <motion.div
+              className="h-full rounded-full"
+              style={{ backgroundColor: accentHex }}
+              animate={{ width: `${((step + 1) / TOUR_STEPS.length) * 100}%` }}
+              transition={{ duration: 0.35 }}
+            />
+          </div>
+
+          {/* Step counter */}
+          <div className="text-xs tracking-[2px] text-zinc-500 mb-5 uppercase">
+            Step {step + 1} <span className="text-zinc-700">/ {TOUR_STEPS.length}</span>
+          </div>
+
+          {/* Icon */}
+          <div className="text-5xl mb-4 leading-none">{current.icon}</div>
+
+          {/* Title */}
+          <h2
+            className="text-2xl font-semibold tracking-tight mb-3"
+            style={{ color: step === 0 || isLast ? accentHex : 'white' }}
+          >
+            {current.title}
+          </h2>
+
+          {/* Description */}
+          <p className="text-zinc-400 text-sm leading-relaxed mb-8">
+            {current.desc}
+          </p>
+
+          {/* Actions */}
+          <div className="flex items-center justify-between gap-3">
+            <button
+              onClick={onClose}
+              className="text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
+            >
+              Skip tour
+            </button>
+            <div className="flex items-center gap-2">
+              {step > 0 && (
+                <button
+                  onClick={prev}
+                  className="px-4 py-2 rounded-xl border border-white/10 text-sm text-zinc-400 hover:bg-white/5 transition-all"
+                >
+                  Back
+                </button>
+              )}
+              <button
+                onClick={next}
+                className="px-6 py-2.5 rounded-xl text-sm font-semibold transition-all active:scale-[0.97] hover:opacity-90"
+                style={{
+                  background: accentHex,
+                  color: isDark ? '#000' : '#fff',
+                }}
+              >
+                {isLast ? 'Get started →' : 'Next →'}
+              </button>
+            </div>
+          </div>
+
+          {/* Progress dots */}
+          <div className="flex gap-1.5 mt-6 justify-center">
+            {TOUR_STEPS.map((_, i) => (
+              <button
+                key={i}
+                onClick={() => setStep(i)}
+                aria-label={`Go to step ${i + 1}`}
+                className="rounded-full transition-all duration-200"
+                style={{
+                  width: i === step ? '16px' : '6px',
+                  height: '6px',
+                  backgroundColor: i === step ? accentHex : i < step ? `${accentHex}55` : 'rgba(255,255,255,0.12)',
+                }}
+              />
+            ))}
+          </div>
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #21

- Add "Create one free" demo callout on login page
- Add Google Sign-In button on login & signup (requires VITE_GOOGLE_CLIENT_ID env var)
- Forgot password modal with reset token generation (link shown in-UI for demo; swap for email in prod)
- /reset-password?token=... page for setting new password
- Persistent login hardened with try/catch around localStorage parse

Generated with [Claude Code](https://claude.ai/code)