### PR TITLE
feat: state-specific meal break reminders for all 50 states

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,13 +3,15 @@ import ReactMarkdown from 'react-markdown'
 import './App.css'
 import './index.css'
 import confetti from 'canvas-confetti'
-import { motion } from 'framer-motion'
+import { motion, AnimatePresence } from 'framer-motion'
 import { toast } from 'sonner'
 import { useTimesheet } from './hooks/useTimesheet'
 import { Rewards } from './components/Rewards'
 import { LootDrop } from './components/LootDrop'
 import { Tour } from './components/Tour'
 import { FeaturePreview } from './components/FeaturePreview'
+import { BreakReminderModal } from './components/BreakReminderModal'
+import { STATE_BREAK_RULES, STATE_CODES } from './data/stateBreakRules'
 
 const API_BASE = (() => {
   const m = window.location.pathname.match(/^(\/hackathon\/preview\/[^/]+)/)
@@ -1127,6 +1129,13 @@ export default function App() {
   const [targetRingConfettiFired, setTargetRingConfettiFired] = useState(false)
   const [overdriveConfettiFired, setOverdriveConfettiFired] = useState(false)
 
+  // State-specific break reminder
+  const [workState, setWorkState] = useState<string>(() => localStorage.getItem('swiftshift-work-state') || 'CA')
+  const [showBreakReminder, setShowBreakReminder] = useState(false)
+  const [breakReminderIsSecond, setBreakReminderIsSecond] = useState(false)
+  // Tracks which reminder thresholds have already fired this clock session (reset on clock-in)
+  const breakReminderFiredRef = useRef<Set<string>>(new Set())
+
   // Daily streak counter (gamified punctuality)
   const [streak, setStreak] = useState<number>(() => {
     const saved = localStorage.getItem('streak')
@@ -1377,6 +1386,46 @@ export default function App() {
       })
     }
   }
+
+  // Persist work state to localStorage
+  useEffect(() => {
+    localStorage.setItem('swiftshift-work-state', workState)
+  }, [workState])
+
+  // Reset break reminder tracking when clocking in
+  useEffect(() => {
+    if (isClockedIn) {
+      breakReminderFiredRef.current = new Set()
+      setShowBreakReminder(false)
+    }
+  }, [isClockedIn])
+
+  // State-specific break reminder logic
+  useEffect(() => {
+    if (!isClockedIn || isOnBreak) return
+    const rule = STATE_BREAK_RULES[workState]
+    if (!rule || rule.triggerAfterHours === 0) return
+
+    const hoursWorked = sessionWorkedMs / 3600000
+
+    // First meal break check
+    if (hoursWorked >= rule.triggerAfterHours && !breakReminderFiredRef.current.has('first')) {
+      breakReminderFiredRef.current.add('first')
+      setBreakReminderIsSecond(false)
+      setShowBreakReminder(true)
+    }
+
+    // Second meal break check (California and similar states)
+    if (
+      rule.secondBreakTriggerHours > 0 &&
+      hoursWorked >= rule.secondBreakTriggerHours &&
+      !breakReminderFiredRef.current.has('second')
+    ) {
+      breakReminderFiredRef.current.add('second')
+      setBreakReminderIsSecond(true)
+      setShowBreakReminder(true)
+    }
+  }, [sessionWorkedMs, isClockedIn, isOnBreak, workState])
 
   const handleClockOut = () => {
     if (isClockedIn) {
@@ -1797,6 +1846,29 @@ export default function App() {
                           Clock out
                         </motion.button>
                       </>
+                    )}
+                  </div>
+
+                  {/* Work state selector for break law compliance */}
+                  <div className="mt-4 flex items-center gap-2">
+                    <span className="text-xs text-zinc-500">Work state:</span>
+                    <select
+                      value={workState}
+                      onChange={e => setWorkState(e.target.value)}
+                      className="text-xs bg-black/40 border border-white/10 rounded-lg px-2 py-1 text-zinc-300 focus:border-white/30 focus:outline-none"
+                    >
+                      {STATE_CODES.map(code => (
+                        <option key={code} value={code}>
+                          {code} — {STATE_BREAK_RULES[code].name}
+                        </option>
+                      ))}
+                    </select>
+                    {STATE_BREAK_RULES[workState]?.triggerAfterHours > 0 ? (
+                      <span className="text-xs text-zinc-500">
+                        · {STATE_BREAK_RULES[workState].mealBreakMinutes}-min break required by hour {STATE_BREAK_RULES[workState].triggerAfterHours + 1}
+                      </span>
+                    ) : (
+                      <span className="text-xs text-zinc-600">· No state break law</span>
                     )}
                   </div>
                     </div>
@@ -3117,6 +3189,19 @@ export default function App() {
             accentHex={themeAccentHex}
           />
         )}
+
+        {/* State-specific meal break reminder */}
+        <BreakReminderModal
+          isOpen={showBreakReminder}
+          rule={STATE_BREAK_RULES[workState]}
+          hoursWorked={sessionWorkedMs / 3600000}
+          isSecondBreak={breakReminderIsSecond}
+          onStartBreak={() => {
+            setShowBreakReminder(false)
+            handleStartBreak()
+          }}
+          onDismiss={() => setShowBreakReminder(false)}
+        />
 
         {/* Clock-out Loot Drop modal */}
         <LootDrop

--- a/frontend/src/components/BreakReminderModal.tsx
+++ b/frontend/src/components/BreakReminderModal.tsx
@@ -1,0 +1,129 @@
+import { motion, AnimatePresence } from 'framer-motion'
+import { StateBreakRule } from '../data/stateBreakRules'
+
+interface BreakReminderModalProps {
+  isOpen: boolean
+  rule: StateBreakRule
+  hoursWorked: number
+  isSecondBreak?: boolean
+  onStartBreak: () => void
+  onDismiss: () => void
+}
+
+export function BreakReminderModal({
+  isOpen,
+  rule,
+  hoursWorked,
+  isSecondBreak = false,
+  onStartBreak,
+  onDismiss,
+}: BreakReminderModalProps) {
+  const hh = Math.floor(hoursWorked)
+  const mm = Math.round((hoursWorked - hh) * 60)
+  const workedLabel = hh > 0 ? `${hh}h ${mm}m` : `${mm}m`
+
+  const breakOrdinal = isSecondBreak ? 'second' : 'first'
+  const title = isSecondBreak
+    ? `Second Meal Break Required`
+    : `Meal Break Required`
+
+  const urgencyColor = hoursWorked >= rule.triggerAfterHours + 0.5 ? '#ef4444' : 'var(--accent-color)'
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          className="fixed inset-0 z-[300] flex items-center justify-center p-4"
+          style={{ background: 'rgba(0,0,0,0.75)', backdropFilter: 'blur(4px)' }}
+          onClick={onDismiss}
+        >
+          <motion.div
+            initial={{ scale: 0.88, opacity: 0, y: 24 }}
+            animate={{ scale: 1, opacity: 1, y: 0 }}
+            exit={{ scale: 0.92, opacity: 0, y: 16 }}
+            transition={{ type: 'spring', stiffness: 320, damping: 28 }}
+            onClick={e => e.stopPropagation()}
+            className="glass rounded-3xl p-8 max-w-md w-full shadow-2xl"
+            style={{ border: `1px solid ${urgencyColor}44` }}
+          >
+            {/* Icon + state badge */}
+            <div className="flex items-center gap-3 mb-5">
+              <div
+                className="w-12 h-12 rounded-2xl flex items-center justify-center text-2xl flex-shrink-0"
+                style={{ background: `${urgencyColor}22`, border: `1px solid ${urgencyColor}44` }}
+              >
+                🍽️
+              </div>
+              <div>
+                <div className="text-xs uppercase tracking-[2px] text-zinc-500">
+                  {rule.name} Labor Law
+                </div>
+                <div className="font-semibold text-lg" style={{ color: urgencyColor }}>
+                  {title}
+                </div>
+              </div>
+            </div>
+
+            {/* Message */}
+            <div className="glass rounded-2xl p-4 mb-5">
+              <p className="text-sm text-zinc-300 leading-relaxed">
+                You've worked <span className="font-semibold text-white">{workedLabel}</span> — {rule.name} requires a{' '}
+                <span className="font-semibold text-white">
+                  {rule.mealBreakMinutes}-minute {rule.isPaid ? 'paid' : 'unpaid'}
+                </span>{' '}
+                meal break before the {isSecondBreak ? '10th' : `${rule.triggerAfterHours + 1}th`} hour of work.
+              </p>
+            </div>
+
+            {/* Law cite */}
+            <div className="text-xs text-zinc-500 mb-6 px-1">
+              {rule.note}
+            </div>
+
+            {/* Progress indicator */}
+            <div className="mb-6">
+              <div className="flex justify-between text-xs text-zinc-500 mb-1.5">
+                <span>Hours worked this session</span>
+                <span className="font-mono" style={{ color: urgencyColor }}>{workedLabel}</span>
+              </div>
+              <div className="h-1.5 rounded-full bg-white/10 overflow-hidden">
+                <motion.div
+                  initial={{ width: 0 }}
+                  animate={{ width: `${Math.min(100, (hoursWorked / (rule.triggerAfterHours + 1)) * 100)}%` }}
+                  transition={{ duration: 0.6, ease: 'easeOut' }}
+                  className="h-full rounded-full"
+                  style={{ background: urgencyColor }}
+                />
+              </div>
+            </div>
+
+            {/* Actions */}
+            <div className="flex gap-3">
+              <motion.button
+                onClick={onStartBreak}
+                whileHover={{ scale: 1.03 }}
+                whileTap={{ scale: 0.96 }}
+                className="flex-1 py-3 rounded-2xl font-semibold text-sm text-black"
+                style={{ background: urgencyColor }}
+              >
+                Start {breakOrdinal} break now
+              </motion.button>
+              <motion.button
+                onClick={onDismiss}
+                whileHover={{ scale: 1.03 }}
+                whileTap={{ scale: 0.96 }}
+                className="px-5 py-3 rounded-2xl text-sm border border-white/20 hover:bg-white/5 text-zinc-400"
+              >
+                Remind later
+              </motion.button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/frontend/src/data/stateBreakRules.ts
+++ b/frontend/src/data/stateBreakRules.ts
@@ -1,0 +1,274 @@
+export interface StateBreakRule {
+  state: string
+  name: string
+  /** Minimum meal break duration in minutes (0 = no state law requirement) */
+  mealBreakMinutes: number
+  /** Hours of net work after which the meal break must have started (0 = no requirement) */
+  triggerAfterHours: number
+  /** Hours for a required second meal break (0 = none) */
+  secondBreakTriggerHours: number
+  /** Whether this break is paid */
+  isPaid: boolean
+  /** Human-readable summary of the law */
+  note: string
+}
+
+export const STATE_BREAK_RULES: Record<string, StateBreakRule> = {
+  AL: {
+    state: 'AL', name: 'Alabama',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement. Federal law applies.',
+  },
+  AK: {
+    state: 'AK', name: 'Alaska',
+    mealBreakMinutes: 30, triggerAfterHours: 5, secondBreakTriggerHours: 0, isPaid: false,
+    note: '30-min unpaid break after 5 consecutive hours of work. (8 AAC 15.165)',
+  },
+  AZ: {
+    state: 'AZ', name: 'Arizona',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement. Federal law applies.',
+  },
+  AR: {
+    state: 'AR', name: 'Arkansas',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement. Federal law applies.',
+  },
+  CA: {
+    state: 'CA', name: 'California',
+    mealBreakMinutes: 30, triggerAfterHours: 4, secondBreakTriggerHours: 9, isPaid: false,
+    note: '30-min unpaid break must START before the 5th hour of work (after 4 hrs). Second 30-min break required before the 10th hour. Employer owes 1 hr premium pay per missed break. (CA Labor Code §512)',
+  },
+  CO: {
+    state: 'CO', name: 'Colorado',
+    mealBreakMinutes: 30, triggerAfterHours: 5, secondBreakTriggerHours: 0, isPaid: false,
+    note: '30-min unpaid meal break when shift exceeds 5 hours. (COMPS Order #38)',
+  },
+  CT: {
+    state: 'CT', name: 'Connecticut',
+    mealBreakMinutes: 30, triggerAfterHours: 7.5, secondBreakTriggerHours: 0, isPaid: false,
+    note: '30-min unpaid break for shifts over 7.5 hours; must occur after first 2 hrs and before last 2 hrs of shift. (CT Gen. Stat. §31-51ii)',
+  },
+  DE: {
+    state: 'DE', name: 'Delaware',
+    mealBreakMinutes: 30, triggerAfterHours: 7.5, secondBreakTriggerHours: 0, isPaid: false,
+    note: '30-min unpaid break for shifts of 7.5+ consecutive hours. (19 Del. C. §707)',
+  },
+  FL: {
+    state: 'FL', name: 'Florida',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement for adults. Federal law applies.',
+  },
+  GA: {
+    state: 'GA', name: 'Georgia',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement. Federal law applies.',
+  },
+  HI: {
+    state: 'HI', name: 'Hawaii',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement for adults. Federal law applies.',
+  },
+  ID: {
+    state: 'ID', name: 'Idaho',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement. Federal law applies.',
+  },
+  IL: {
+    state: 'IL', name: 'Illinois',
+    mealBreakMinutes: 20, triggerAfterHours: 7.5, secondBreakTriggerHours: 0, isPaid: false,
+    note: '20-min unpaid break for shifts over 7.5 hours; break must begin no later than 5 hrs after shift start. (820 ILCS 140/3)',
+  },
+  IN: {
+    state: 'IN', name: 'Indiana',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement for adults. Federal law applies.',
+  },
+  IA: {
+    state: 'IA', name: 'Iowa',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement. Federal law applies.',
+  },
+  KS: {
+    state: 'KS', name: 'Kansas',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement. Federal law applies.',
+  },
+  KY: {
+    state: 'KY', name: 'Kentucky',
+    mealBreakMinutes: 30, triggerAfterHours: 5, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'Reasonable off-duty meal period (≥30 min) required for employees working more than 5 consecutive hours. (KRS 337.365)',
+  },
+  LA: {
+    state: 'LA', name: 'Louisiana',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement. Federal law applies.',
+  },
+  ME: {
+    state: 'ME', name: 'Maine',
+    mealBreakMinutes: 30, triggerAfterHours: 6, secondBreakTriggerHours: 0, isPaid: false,
+    note: '30-min unpaid break for shifts of more than 6 consecutive hours. (26 M.R.S. §601)',
+  },
+  MD: {
+    state: 'MD', name: 'Maryland',
+    mealBreakMinutes: 30, triggerAfterHours: 8, secondBreakTriggerHours: 0, isPaid: false,
+    note: '30-min unpaid break for each 8-hour consecutive work period. (MD Code, Lab. & Empl. §3-420)',
+  },
+  MA: {
+    state: 'MA', name: 'Massachusetts',
+    mealBreakMinutes: 30, triggerAfterHours: 6, secondBreakTriggerHours: 0, isPaid: false,
+    note: '30-min unpaid break for shifts of more than 6 hours per day. (MGL c.149 §100)',
+  },
+  MI: {
+    state: 'MI', name: 'Michigan',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement for adults. Federal law applies.',
+  },
+  MN: {
+    state: 'MN', name: 'Minnesota',
+    mealBreakMinutes: 30, triggerAfterHours: 8, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'Sufficient time to eat (≥30 min) must be provided for 8-hour shifts. (MN Stat. §177.253)',
+  },
+  MS: {
+    state: 'MS', name: 'Mississippi',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement. Federal law applies.',
+  },
+  MO: {
+    state: 'MO', name: 'Missouri',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement. Federal law applies.',
+  },
+  MT: {
+    state: 'MT', name: 'Montana',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement for most industries. Federal law applies.',
+  },
+  NE: {
+    state: 'NE', name: 'Nebraska',
+    mealBreakMinutes: 30, triggerAfterHours: 8, secondBreakTriggerHours: 0, isPaid: false,
+    note: '30-min off-duty meal break for shifts of 8+ hours. (NE Rev. Stat. §48-212)',
+  },
+  NV: {
+    state: 'NV', name: 'Nevada',
+    mealBreakMinutes: 30, triggerAfterHours: 8, secondBreakTriggerHours: 0, isPaid: false,
+    note: '30-min unpaid meal break for shifts of 8+ hours. (NRS 608.019)',
+  },
+  NH: {
+    state: 'NH', name: 'New Hampshire',
+    mealBreakMinutes: 30, triggerAfterHours: 5, secondBreakTriggerHours: 0, isPaid: false,
+    note: '30-min break after 5 consecutive hours of work. (RSA 275:30-a)',
+  },
+  NJ: {
+    state: 'NJ', name: 'New Jersey',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement for adults. Federal law applies.',
+  },
+  NM: {
+    state: 'NM', name: 'New Mexico',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement. Federal law applies.',
+  },
+  NY: {
+    state: 'NY', name: 'New York',
+    mealBreakMinutes: 30, triggerAfterHours: 6, secondBreakTriggerHours: 0, isPaid: false,
+    note: '30-min unpaid meal break for shifts over 6 hours; timing depends on shift start time. Factory workers get 60 min between 11am–2pm. (NY Labor Law §162)',
+  },
+  NC: {
+    state: 'NC', name: 'North Carolina',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement for adults. Federal law applies.',
+  },
+  ND: {
+    state: 'ND', name: 'North Dakota',
+    mealBreakMinutes: 30, triggerAfterHours: 5, secondBreakTriggerHours: 0, isPaid: false,
+    note: '30-min unpaid break for shifts over 5 hours. (N.D. Admin. Code §46-02-07-02)',
+  },
+  OH: {
+    state: 'OH', name: 'Ohio',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement for adults. Federal law applies.',
+  },
+  OK: {
+    state: 'OK', name: 'Oklahoma',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement. Federal law applies.',
+  },
+  OR: {
+    state: 'OR', name: 'Oregon',
+    mealBreakMinutes: 30, triggerAfterHours: 6, secondBreakTriggerHours: 0, isPaid: false,
+    note: '30-min unpaid meal break for shifts of 6+ hours. (ORS 653.261)',
+  },
+  PA: {
+    state: 'PA', name: 'Pennsylvania',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement for adults. Federal law applies.',
+  },
+  RI: {
+    state: 'RI', name: 'Rhode Island',
+    mealBreakMinutes: 20, triggerAfterHours: 6, secondBreakTriggerHours: 0, isPaid: false,
+    note: '20-min unpaid break for employees working a 6-hour period. (RIGL §28-3-14)',
+  },
+  SC: {
+    state: 'SC', name: 'South Carolina',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement. Federal law applies.',
+  },
+  SD: {
+    state: 'SD', name: 'South Dakota',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement. Federal law applies.',
+  },
+  TN: {
+    state: 'TN', name: 'Tennessee',
+    mealBreakMinutes: 30, triggerAfterHours: 6, secondBreakTriggerHours: 0, isPaid: false,
+    note: '30-min unpaid break for employees working 6 consecutive hours. (T.C.A. §50-2-103)',
+  },
+  TX: {
+    state: 'TX', name: 'Texas',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement. Federal law applies.',
+  },
+  UT: {
+    state: 'UT', name: 'Utah',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement. Federal law applies.',
+  },
+  VT: {
+    state: 'VT', name: 'Vermont',
+    mealBreakMinutes: 30, triggerAfterHours: 6, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'Employers must provide a reasonable meal opportunity (typically 30 min) for reasonable shift lengths. (21 VSA §304)',
+  },
+  VA: {
+    state: 'VA', name: 'Virginia',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement for adults. Federal law applies.',
+  },
+  WA: {
+    state: 'WA', name: 'Washington',
+    mealBreakMinutes: 30, triggerAfterHours: 5, secondBreakTriggerHours: 0, isPaid: false,
+    note: '30-min unpaid meal period for employees working more than 5 hours. (WAC 296-126-092)',
+  },
+  WV: {
+    state: 'WV', name: 'West Virginia',
+    mealBreakMinutes: 20, triggerAfterHours: 6, secondBreakTriggerHours: 0, isPaid: false,
+    note: '20-min unpaid meal break per 6 hours worked. (W.Va. Code §21-3-10a)',
+  },
+  WI: {
+    state: 'WI', name: 'Wisconsin',
+    mealBreakMinutes: 30, triggerAfterHours: 6, secondBreakTriggerHours: 0, isPaid: false,
+    note: '30-min meal break is recommended (state guidance, not legally mandated). (DWD Wis. Stat. §104.066)',
+  },
+  WY: {
+    state: 'WY', name: 'Wyoming',
+    mealBreakMinutes: 0, triggerAfterHours: 0, secondBreakTriggerHours: 0, isPaid: false,
+    note: 'No state meal break requirement. Federal law applies.',
+  },
+  DC: {
+    state: 'DC', name: 'Washington D.C.',
+    mealBreakMinutes: 30, triggerAfterHours: 6, secondBreakTriggerHours: 0, isPaid: false,
+    note: '30-min unpaid break for shifts over 6 consecutive hours. (D.C. Code §32-1001 et seq.)',
+  },
+}
+
+export const STATE_CODES = Object.keys(STATE_BREAK_RULES).sort()


### PR DESCRIPTION
Closes #42

Adds state-specific meal break reminder popups for all 50 US states + DC, based on each state's labor law.

**What's included:**
- `stateBreakRules.ts` data file with meal break laws for every state (trigger hours, break duration, paid/unpaid, law cite)
- `BreakReminderModal` animated popup component (Framer Motion)
- Work state selector dropdown in the clock view (defaults to CA)
- Reminder fires based on net worked hours for the selected state's threshold
- California second meal break (before 10th hour) also supported

Generated with [Claude Code](https://claude.ai/code)