### PR TITLE
feat: rewards tab hourly rate persistence and UX improvements

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -927,6 +927,15 @@ export default function App() {
 
   // Main app
   const [activeView, setActiveView] = useState<View>('clock')
+  const [clockHourlyRate, setClockHourlyRate] = useState<number>(() => {
+    const saved = localStorage.getItem('swiftshift-hourly-rate')
+    if (saved) return parseFloat(saved)
+    const salary = Number(user?.salary) || 0
+    if (salary > 0) return salary / 2080
+    const pay = Number(user?.pay)
+    return pay > 0 ? pay : 65
+  })
+  const [highlightRate, setHighlightRate] = useState(false)
   const [showTour, setShowTour] = useState(() => localStorage.getItem('swiftshift-tour-pending') === '1')
   const [chatMessage, setChatMessage] = useState('')
   const [chatLoading, setChatLoading] = useState(false)
@@ -955,6 +964,18 @@ export default function App() {
     setActiveView(view)
     setMobileMenuOpen(false)
   }
+
+  const navToRewardsWithHighlight = () => {
+    setHighlightRate(true)
+    navTo('rewards')
+  }
+
+  // Auto-clear highlight after animation completes
+  useEffect(() => {
+    if (!highlightRate) return
+    const timer = setTimeout(() => setHighlightRate(false), 2500)
+    return () => clearTimeout(timer)
+  }, [highlightRate])
 
   const orgData = {
     id: 'ceo',
@@ -1474,10 +1495,9 @@ export default function App() {
       setPaidBreakMsAccum(0)
 
       // Show LootDrop modal with earnings and PTO
-      const hourlyRate = 65
       const ptoAccrualRate = 0.0385
       const hoursWorked = session / 3600000
-      setLootEarnings(Math.round(hoursWorked * hourlyRate * 100) / 100)
+      setLootEarnings(Math.round(hoursWorked * clockHourlyRate * 100) / 100)
       setLootPtoHours(Math.round(hoursWorked * ptoAccrualRate * 100) / 100)
       setLootDurationMin(Math.round(session / 60000))
       setShowLootDrop(true)
@@ -2048,15 +2068,21 @@ export default function App() {
                 <div className="glass rounded-3xl p-8 flex-1">
                   <div className="text-sm uppercase tracking-[2px] text-white mb-3">Real Time Rewards</div>
                   <div className="mb-3">
-                    <div className="text-xs text-zinc-400 mb-1">Today's Earnings</div>
+                    <button
+                      onClick={navToRewardsWithHighlight}
+                      className="text-xs text-zinc-400 hover:text-white mb-1 text-left underline decoration-zinc-600 hover:decoration-white transition-colors cursor-pointer leading-snug"
+                      title="Click to update your hourly rate on the Rewards tab"
+                    >
+                      Today's earnings so far at ${clockHourlyRate}/hr
+                    </button>
                     <motion.div
-                      key={Math.floor((todayTotalMs / 3600000) * 65 * 10)}
+                      key={Math.floor((todayTotalMs / 3600000) * clockHourlyRate * 10)}
                       initial={isClockedIn ? { scale: 1.08, color: 'var(--accent-color)' } : false}
                       animate={{ scale: 1, color: 'var(--accent-color)' }}
                       transition={{ duration: 0.25 }}
                       className="font-mono text-5xl font-bold tabular-nums neon-green"
                     >
-                      ${((todayTotalMs / 3600000) * 65).toFixed(2)}
+                      ${((todayTotalMs / 3600000) * clockHourlyRate).toFixed(2)}
                     </motion.div>
                     {isClockedIn && (
                       <div className="flex items-center gap-1.5 mt-0.5">
@@ -2096,6 +2122,8 @@ export default function App() {
               isClockedIn={isClockedIn}
               theme={theme}
               user={user}
+              highlightRate={highlightRate}
+              onRateChange={(rate) => setClockHourlyRate(rate)}
             />
           )}
           {activeView === 'admin' && (

--- a/frontend/src/components/Rewards.tsx
+++ b/frontend/src/components/Rewards.tsx
@@ -9,9 +9,15 @@ interface RewardsProps {
   theme?: 'green' | 'white' | 'orange' | 'cyan' | 'pink' | 'purple'
   user?: any
   onFocus?: () => void
+  highlightRate?: boolean
+  onRateChange?: (rate: number) => void
 }
 
+const HOURLY_RATE_KEY = 'swiftshift-hourly-rate'
+
 function computeHourlyRate(user: any): number {
+  const saved = localStorage.getItem(HOURLY_RATE_KEY)
+  if (saved) return parseFloat(saved)
   const salary = Number(user?.salary) || 0
   if (salary > 0) return salary / 2080
   const pay = Number(user?.pay)
@@ -20,13 +26,15 @@ function computeHourlyRate(user: any): number {
 
 const LEVEL_NAMES = ['Rookie', 'Associate', 'Pro', 'Senior', 'Expert', 'Elite', 'Master', 'Legend']
 
-export function Rewards({ totalHours, elapsedSeconds, isClockedIn, theme = 'green', user, onFocus }: RewardsProps) {
+export function Rewards({ totalHours, elapsedSeconds, isClockedIn, theme = 'green', user, onFocus, highlightRate, onRateChange }: RewardsProps) {
   const [hourlyRate, setHourlyRate] = useState(() => computeHourlyRate(user))
   const [ptoAccrualRate, setPtoAccrualRate] = useState(1 / 30)
   const [hasFiredConfetti, setHasFiredConfetti] = useState(false)
   const [streak, setStreak] = useState(0)
   const prevCentsRef = useRef(0)
   const containerRef = useRef<HTMLDivElement>(null)
+  const rateInputRef = useRef<HTMLInputElement>(null)
+  const rateCardRef = useRef<HTMLDivElement>(null)
 
   const liveTodayEarnings = isClockedIn ? (elapsedSeconds / 3600) * hourlyRate : 0
   const earnedToday = liveTodayEarnings
@@ -139,6 +147,23 @@ export function Rewards({ totalHours, elapsedSeconds, isClockedIn, theme = 'gree
     triggerHaptic(Math.floor(earnedToday * 100) % 100)
   }, [earnedToday, isClockedIn, triggerHaptic])
 
+  // Persist hourly rate changes and notify parent
+  useEffect(() => {
+    localStorage.setItem(HOURLY_RATE_KEY, String(hourlyRate))
+    onRateChange?.(hourlyRate)
+  }, [hourlyRate]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Scroll to and highlight rate input when triggered from clock view
+  useEffect(() => {
+    if (!highlightRate) return
+    const timer = setTimeout(() => {
+      rateCardRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      rateInputRef.current?.focus()
+      rateInputRef.current?.select()
+    }, 150)
+    return () => clearTimeout(timer)
+  }, [highlightRate])
+
   // Confetti on tab focus
   useEffect(() => {
     if (onFocus && !hasFiredConfetti) {
@@ -162,23 +187,9 @@ export function Rewards({ totalHours, elapsedSeconds, isClockedIn, theme = 'gree
           ═══════════════════════════════════════════ */}
       <div className="glass rounded-3xl p-6">
         {/* Header */}
-        <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center justify-between mb-4">
           <div className="text-2xl font-semibold neon-green">Rewards</div>
           <div className="flex items-center gap-4 text-sm">
-            <div className="flex items-center gap-2">
-              <span className="text-zinc-500">Rate:</span>
-              <div className="flex items-center bg-zinc-900 rounded-xl px-3 py-1.5">
-                <span className="text-zinc-400">$</span>
-                <input
-                  type="number"
-                  value={hourlyRate}
-                  onChange={(e) => setHourlyRate(Math.max(1, parseInt(e.target.value) || 0))}
-                  className="w-16 bg-transparent text-right font-mono focus:outline-none"
-                  min="1"
-                />
-                <span className="text-zinc-400">/hr</span>
-              </div>
-            </div>
             <div className="flex items-center gap-2">
               <span className="text-zinc-500">PTO:</span>
               <div className="flex items-center bg-zinc-900 rounded-xl px-3 py-1.5">
@@ -196,6 +207,49 @@ export function Rewards({ totalHours, elapsedSeconds, isClockedIn, theme = 'gree
             <div className="text-right">
               <div className="text-[10px] text-zinc-500">Weekly earnings</div>
               <div className="font-semibold tabular-nums neon-green">${totalEarnings.toFixed(0)}</div>
+            </div>
+          </div>
+        </div>
+
+        {/* ── HOURLY RATE — prominent editable card ── */}
+        <div
+          ref={rateCardRef}
+          className="rounded-2xl mb-4 px-5 py-4 flex items-center justify-between gap-4 transition-all duration-300"
+          style={{
+            background: highlightRate
+              ? `linear-gradient(135deg, ${accentColor}22 0%, ${accentColor}0A 100%)`
+              : 'rgba(255,255,255,0.04)',
+            border: highlightRate
+              ? `1.5px solid ${accentColor}`
+              : '1.5px solid rgba(255,255,255,0.08)',
+            boxShadow: highlightRate
+              ? `0 0 20px ${accentColor}40, 0 0 40px ${accentColor}20`
+              : 'none',
+          }}
+        >
+          <div>
+            <div className="text-xs uppercase tracking-[2px] text-zinc-400 mb-0.5">Your Hourly Rate</div>
+            <div className="text-xs text-zinc-600">Click the amount to edit your rate</div>
+          </div>
+          <div className="flex items-center gap-3">
+            <div
+              className="flex items-center rounded-xl px-4 py-2.5 gap-1 transition-all duration-300"
+              style={{
+                background: highlightRate ? `${accentColor}18` : 'rgba(0,0,0,0.4)',
+                border: highlightRate ? `1.5px solid ${accentColor}80` : '1.5px solid rgba(255,255,255,0.1)',
+              }}
+            >
+              <span className="text-zinc-300 text-xl font-light">$</span>
+              <input
+                ref={rateInputRef}
+                type="number"
+                value={hourlyRate}
+                onChange={(e) => setHourlyRate(Math.max(1, parseInt(e.target.value) || 0))}
+                className="w-20 bg-transparent text-right font-mono text-3xl font-bold focus:outline-none"
+                style={{ color: accentColor }}
+                min="1"
+              />
+              <span className="text-zinc-400 text-base">/hr</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Fixes #54

**Changes:**
- Hourly rate is now persisted to localStorage so it no longer reverts on navigation
- Clock view shows "Today's earnings so far at $X/hr" using the live rate, clickable to edit
- Clicking the rate link navigates to Rewards tab and highlights the rate input
- Rewards tab has a prominent "Your Hourly Rate" card with large editable input
- LootDrop modal now uses persisted rate instead of hardcoded $65

Generated with [Claude Code](https://claude.ai/code)