### PR TITLE
fix: resolve TypeScript build error in BreakReminderModal callback

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3274,7 +3274,7 @@ export default function App() {
           isSecondBreak={breakReminderIsSecond}
           onStartBreak={() => {
             setShowBreakReminder(false)
-            handleStartBreak()
+            handleStartBreak(STATE_BREAK_RULES[workState]?.isPaid ? 'paid' : 'unpaid')
           }}
           onDismiss={() => setShowBreakReminder(false)}
         />


### PR DESCRIPTION
Fixes TypeScript error TS2554: `handleStartBreak` was called with 0 arguments but requires 1 (`'paid' | 'unpaid'`).

Now correctly passes the break type based on the state rule's `isPaid` property, so state-mandated meal breaks are tracked correctly as paid or unpaid.

Closes #58

Generated with [Claude Code](https://claude.ai/code)