### PR TITLE
Prepare for production deployment on swiftshift.work

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# PostgreSQL connection string (Railway provides this automatically as DATABASE_URL)
+DATABASE_URL=postgresql://user:password@host:5432/swiftshift
+
+# Comma-separated list of allowed CORS origins
+# For production: https://swiftshift.work
+# For local dev: http://localhost:5173
+ALLOWED_ORIGINS=https://swiftshift.work
+
+# OpenAI API key (used by Grok AI features)
+OPENAI_API_KEY=sk-...
+
+# Port to listen on (Railway sets this automatically)
+PORT=8000

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: cd backend && gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT

--- a/backend/app.py
+++ b/backend/app.py
@@ -15,26 +15,6 @@ app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024  # 50MB uploads
 _allowed_origins = os.environ.get("ALLOWED_ORIGINS", "*").split(",")
 CORS(app, origins=_allowed_origins)
 
-# Subpath for preview deployment (must be defined before routes)
-SUBPATH = "/hackathon/preview/doesitworkday"
-
-
-class SubpathMiddleware:
-    """Strip SUBPATH prefix so blueprint routes match under preview subpath."""
-    def __init__(self, app, prefix):
-        self.app = app
-        self.prefix = prefix.rstrip("/")
-
-    def __call__(self, environ, start_response):
-        path = environ.get("PATH_INFO", "")
-        if path.startswith(self.prefix + "/"):
-            environ["SCRIPT_NAME"] = self.prefix
-            environ["PATH_INFO"] = path[len(self.prefix):]
-        return self.app(environ, start_response)
-
-
-app.wsgi_app = SubpathMiddleware(app.wsgi_app, SUBPATH)
-
 
 @app.route("/api/kalshi/markets")
 def kalshi_markets():
@@ -80,10 +60,6 @@ app.register_blueprint(jobs_bp)
 @app.route("/", defaults={"path": ""})
 @app.route("/<path:path>")
 def serve_frontend(path):
-    # Strip subpath prefix if present (for preview proxy)
-    if path.startswith(SUBPATH.lstrip("/") + "/"):
-        path = path[len(SUBPATH):].lstrip("/")
-    # API paths go to blueprints (after subpath stripping)
     if path.startswith("api/"):
         return jsonify({"error": "Not found"}), 404
     file_path = os.path.join(frontend_dir, path)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ pypdf>=4.0.0
 python-docx>=1.1.0
 pytest>=8.0.0
 requests
+gunicorn>=21.0.0

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,10 +13,7 @@ import { FeaturePreview } from './components/FeaturePreview'
 import { BreakReminderModal } from './components/BreakReminderModal'
 import { STATE_BREAK_RULES, STATE_CODES } from './data/stateBreakRules'
 
-const API_BASE = (() => {
-  const m = window.location.pathname.match(/^(\/hackathon\/preview\/[^/]+)/)
-  return m ? m[1] : ''
-})()
+const API_BASE = ''
 
 type View = 'clock' | 'timesheet' | 'rewards' | 'admin' | 'profile' | 'insurance' | 'orgchart' | 'taxes' | 'groktax' | 'grokky' | 'applications' | 'jobs' | 'schedules' | 'payroll' | 'reports' | 'leaves' | 'compliance' | 'hiring'
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,52 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-const SUBPATH = '/hackathon/preview/doesitworkday/'
-
 export default defineConfig({
-  base: SUBPATH,
-  plugins: [
-    react(),
-    {
-      name: 'no-redirect',
-      configurePreviewServer(server) {
-        server.middlewares.stack.unshift({
-          route: '',
-          handle: (req: any, res: any, next: any) => {
-            if (req.url === '/' || req.url === '') {
-              req.url = '/index.html'
-            }
-            next()
-          },
-        } as any)
-      },
-    },
-  ],
+  base: '/',
+  plugins: [react()],
   server: {
     host: '0.0.0.0',
     port: 5173,
     strictPort: true,
-    allowedHosts: ['autoqa.teachx.ai'],
-    watch: {
-      usePolling: true,
-    },
-    headers: {
-      'Cache-Control': 'no-cache',
-    },
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8000',
-        changeOrigin: true,
-      },
-    },
-  },
-  preview: {
-    host: '0.0.0.0',
-    port: 5173,
-    strictPort: true,
-    headers: {
-      'Cache-Control': 'no-cache',
-    },
     proxy: {
       '/api': {
         target: 'http://localhost:8000',

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,7 @@
+[build]
+buildCommand = "./build.sh"
+
+[deploy]
+startCommand = "cd backend && gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT"
+healthcheckPath = "/api/health"
+restartPolicyType = "on_failure"


### PR DESCRIPTION
Prepares the app for production deployment on swiftshift.work:

- Remove hackathon preview subpath from Vite config (base: '/')
- Remove SubpathMiddleware from Flask backend
- Simplify API_BASE in App.tsx to same-origin
- Add gunicorn to requirements
- Add railway.toml and Procfile for Railway deployment
- Add .env.example documenting all environment variables

Closes #52

Generated with [Claude Code](https://claude.ai/code)