### PR TITLE
Fix Railway deploy: sh build.sh and XAI_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,8 @@ DATABASE_URL=postgresql://user:password@host:5432/swiftshift
 # For local dev: http://localhost:5173
 ALLOWED_ORIGINS=https://swiftshift.work
 
-# OpenAI API key (used by Grok AI features)
-OPENAI_API_KEY=sk-...
+# xAI API key for Grok (get yours at console.x.ai)
+XAI_API_KEY=xai-...
 
 # Port to listen on (Railway sets this automatically)
 PORT=8000

--- a/railway.toml
+++ b/railway.toml
@@ -1,5 +1,5 @@
 [build]
-buildCommand = "./build.sh"
+buildCommand = "sh build.sh"
 
 [deploy]
 startCommand = "cd backend && gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT"


### PR DESCRIPTION
Fixes Railway deployment failures:

- Change buildCommand from `./build.sh` to `sh build.sh` to avoid permission denied (exit code 126)
- Update .env.example to use XAI_API_KEY instead of OPENAI_API_KEY (code already uses xAI/Grok API)

Closes #52

Generated with [Claude Code](https://claude.ai/code)