### PR TITLE
Fix Railway build: add mise.toml so Node.js is installed for frontend build

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+node = "20"
+python = "3.11"


### PR DESCRIPTION
Fixes `npm: not found` error during Railway deployment.

Railpack was only detecting Python and not installing Node.js, so `npm` was unavailable when `build.sh` tried to build the React frontend.

Added `mise.toml` at the repo root specifying both `node = "20"` and `python = "3.11"` so Railpack installs both runtimes before building.

Closes #52

Generated with [Claude Code](https://claude.ai/code)