### PR TITLE
fix: move database init from build phase to runtime startup

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,9 +10,6 @@ cd ..
 echo "Installing backend dependencies..."
 cd backend
 pip install -r requirements.txt
-
-echo "Setting up database tables..."
-python init_db.py
 cd ..
 
 echo "Done!"

--- a/railway.toml
+++ b/railway.toml
@@ -2,6 +2,6 @@
 buildCommand = "sh build.sh"
 
 [deploy]
-startCommand = "cd backend && gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT"
+startCommand = "cd backend && python init_db.py && gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT"
 healthcheckPath = "/api/health"
 restartPolicyType = "on_failure"


### PR DESCRIPTION
Fixes #65

The build was failing because `build.sh` called `python init_db.py` during Railway's build phase, where the Postgres database is not yet reachable. The DATABASE_URL hostname could not resolve, causing the build to exit with code 1.

**Changes:**
- Removed `python init_db.py` from `build.sh`
- Added `python init_db.py &&` to the `startCommand` in `railway.toml` so tables are initialized at runtime when the database is accessible

Generated with [Claude Code](https://claude.ai/code)