### PR TITLE
fix: use python3 in railway.toml start command

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -2,6 +2,6 @@
 buildCommand = "sh build.sh"
 
 [deploy]
-startCommand = "cd backend && python init_db.py && gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT"
+startCommand = "cd backend && python3 init_db.py && gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT"
 healthcheckPath = "/api/health"
 restartPolicyType = "on_failure"


### PR DESCRIPTION
Fixes #65

Railway's mise-managed Python runtime registers as `python3`, not `python`. The start command `python init_db.py` failed immediately at container startup, so gunicorn never launched, causing the healthcheck to time out.

**Change:** Updated `railway.toml` start command to use `python3 init_db.py` instead of `python init_db.py`.

Generated with [Claude Code](https://claude.ai/code)