### PR TITLE
fix: add mise shims to PATH in Railway deploy command

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: cd backend && gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT
+web: bash -c 'export PATH=/root/.local/share/mise/shims:$PATH && cd backend && gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT'

--- a/railway.toml
+++ b/railway.toml
@@ -2,6 +2,6 @@
 buildCommand = "sh build.sh"
 
 [deploy]
-startCommand = "cd backend && python3 init_db.py && gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT"
+startCommand = "bash -c 'export PATH=/root/.local/share/mise/shims:$PATH && cd backend && python3 init_db.py && gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT'"
 healthcheckPath = "/api/health"
 restartPolicyType = "on_failure"


### PR DESCRIPTION
Fixes #69

Railway's Railpack uses separate build and runtime containers. Python 3.11 is installed via `mise` during build, but the runtime container doesn't have the mise shims directory in PATH. This adds `/root/.local/share/mise/shims` to PATH in both `railway.toml` and `Procfile` so python3, gunicorn and other mise-managed binaries are found at container startup.

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/GiTD67/SwiftShift/actions/runs/24861215715