### PR TITLE
UI overhaul: timesheet sidebar, rewards layout, overdrive mode

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1237,6 +1237,7 @@ export default function App() {
     ? Math.max(0, now.getTime() - clockInAt.getTime() - breakMsAccum - unpaidActiveBreakMs)
     : 0
   const todayTotalMs = todayWorkedMs + sessionWorkedMs
+  const isOvertimeOverdrive = todayTotalMs >= 8 * 3600000
 
   const statusText = !isClockedIn
     ? 'Not clocked in'
@@ -1256,7 +1257,6 @@ export default function App() {
           duration: 8000,
           style: {
             background: '#111111',
-            border: `1px solid ${getThemeAccentHex(theme)}`,
             color: '#ffffff',
           },
         })
@@ -1608,7 +1608,7 @@ export default function App() {
   }
 
   return (
-    <div className="ta-app" data-theme={theme}>
+    <div className="ta-app" data-theme={theme} data-overdrive={isOvertimeOverdrive ? 'true' : undefined}>
       <nav className="ta-navbar">
         <div className="flex items-center gap-2">
           {/* Hamburger (mobile only) */}
@@ -2047,47 +2047,42 @@ export default function App() {
 
               </div>
 
-              {/* Right sidebar: This pay period + Real Time Rewards */}
+              {/* Right sidebar: Real Time Rewards (top) + This pay period */}
               <aside className="xl:w-80 shrink-0 flex flex-col sm:flex-row xl:flex-col gap-4">
+                {/* Real Time Rewards module — at top */}
                 <div className="glass rounded-3xl p-8 flex-1">
-                  <div className="text-sm uppercase tracking-[2px] text-white mb-3">This pay period</div>
-                  <div className="text-lg font-medium mb-2 neon-green">{periodLabel}</div>
-                  <div className="text-sm text-zinc-400 mb-4">Regular hours: <span className="font-mono neon-green">{periodHours}</span> hrs</div>
-                  <button
-                    onClick={() => navTo('timesheet')}
-                    className="text-sm underline decoration-white/30 hover:decoration-white"
+                  <div className="text-sm uppercase tracking-[2px] text-white mb-5">Real Time Rewards</div>
+                  <motion.div
+                    key={Math.floor((todayTotalMs / 3600000) * clockHourlyRate * 10)}
+                    initial={isClockedIn ? { scale: 1.08, color: 'var(--accent-color)' } : false}
+                    animate={{ scale: 1, color: 'var(--accent-color)' }}
+                    transition={{ duration: 0.25 }}
+                    className="font-mono text-5xl font-bold tabular-nums neon-green mb-5"
                   >
-                    See my time →
-                  </button>
-                </div>
-
-                {/* Real Time Rewards module */}
-                <div className="glass rounded-3xl p-8 flex-1">
-                  <div className="text-sm uppercase tracking-[2px] text-white mb-3">Real Time Rewards</div>
-                  <div className="mb-3">
+                    ${((todayTotalMs / 3600000) * clockHourlyRate).toFixed(2)}
+                  </motion.div>
+                  <div className="flex items-center justify-between mb-5">
                     <button
                       onClick={navToRewardsWithHighlight}
-                      className="text-xs text-zinc-400 hover:text-white mb-1 text-left underline decoration-zinc-600 hover:decoration-white transition-colors cursor-pointer leading-snug"
+                      className="text-xs text-zinc-400 hover:text-white text-left underline decoration-zinc-600 hover:decoration-white transition-colors cursor-pointer leading-snug"
                       title="Click to update your hourly rate on the Rewards tab"
                     >
                       Today's earnings so far at ${clockHourlyRate}/hr
                     </button>
-                    <motion.div
-                      key={Math.floor((todayTotalMs / 3600000) * clockHourlyRate * 10)}
-                      initial={isClockedIn ? { scale: 1.08, color: 'var(--accent-color)' } : false}
-                      animate={{ scale: 1, color: 'var(--accent-color)' }}
-                      transition={{ duration: 0.25 }}
-                      className="font-mono text-5xl font-bold tabular-nums neon-green"
-                    >
-                      ${((todayTotalMs / 3600000) * clockHourlyRate).toFixed(2)}
-                    </motion.div>
                     {isClockedIn && (
-                      <div className="flex items-center gap-1.5 mt-0.5">
+                      <div className="flex items-center gap-1.5 flex-shrink-0 ml-3">
                         <span
                           className="w-2.5 h-2.5 rounded-full animate-pulse inline-block"
-                          style={{ background: '#22ff7a', boxShadow: '0 0 8px #22ff7a, 0 0 16px #22ff7a60' }}
+                          style={{
+                            background: isOvertimeOverdrive ? '#FFD700' : '#22ff7a',
+                            boxShadow: isOvertimeOverdrive
+                              ? '0 0 8px #FFD700, 0 0 16px #FFD70060'
+                              : '0 0 8px #22ff7a, 0 0 16px #22ff7a60',
+                          }}
                         />
-                        <span className="text-xs uppercase tracking-widest text-zinc-300 font-medium">live</span>
+                        <span className="text-xs uppercase tracking-widest text-zinc-300 font-medium">
+                          {isOvertimeOverdrive ? 'overdrive' : 'live'}
+                        </span>
                       </div>
                     )}
                   </div>
@@ -2102,6 +2097,44 @@ export default function App() {
                     className="text-sm underline decoration-white/30 hover:decoration-white"
                   >
                     See rewards →
+                  </button>
+                </div>
+
+                {/* This pay period — below Real Time Rewards */}
+                <div className="glass rounded-3xl p-8 flex-1">
+                  <div className="text-sm uppercase tracking-[2px] text-white mb-4">This pay period</div>
+                  <div className="text-base font-medium mb-4 neon-green">{periodLabel}</div>
+                  <div className="space-y-3 mb-4">
+                    <div className="flex justify-between items-center text-sm">
+                      <span className="text-zinc-400">Regular hours</span>
+                      <span className="font-mono neon-green">{periodHours} hrs</span>
+                    </div>
+                    <div className="flex justify-between items-center text-sm">
+                      <span className="text-zinc-400">Earned this period</span>
+                      <span className="font-mono neon-green">${(parseFloat(periodHours) * clockHourlyRate).toFixed(0)}</span>
+                    </div>
+                    <div className="flex justify-between items-center text-sm">
+                      <span className="text-zinc-400">Days remaining</span>
+                      <span className="font-mono neon-green">
+                        {Math.max(0, Math.ceil((period.end.getTime() - now.getTime()) / 86400000))} days
+                      </span>
+                    </div>
+                  </div>
+                  <div className="crystal-progress mb-4">
+                    <div
+                      className="crystal-progress-fill"
+                      style={{
+                        width: `${Math.min(100, Math.round(
+                          (1 - Math.max(0, Math.ceil((period.end.getTime() - now.getTime()) / 86400000)) / 14) * 100
+                        ))}%`,
+                      }}
+                    />
+                  </div>
+                  <button
+                    onClick={() => navTo('timesheet')}
+                    className="text-sm underline decoration-white/30 hover:decoration-white"
+                  >
+                    See my time →
                   </button>
                 </div>
               </aside>

--- a/frontend/src/components/Rewards.tsx
+++ b/frontend/src/components/Rewards.tsx
@@ -189,73 +189,14 @@ export function Rewards({ totalHours, elapsedSeconds, isClockedIn, theme = 'gree
         {/* Header */}
         <div className="flex items-center justify-between mb-4">
           <div className="text-2xl font-semibold neon-green">Rewards</div>
-          <div className="flex items-center gap-4 text-sm">
-            <div className="flex items-center gap-2">
-              <span className="text-zinc-500">PTO:</span>
-              <div className="flex items-center bg-zinc-900 rounded-xl px-3 py-1.5">
-                <span className="text-zinc-400">1 hr /</span>
-                <input
-                  type="number"
-                  value={(1 / ptoAccrualRate).toFixed(0)}
-                  onChange={(e) => setPtoAccrualRate(Math.max(0.001, 1 / Math.max(1, parseFloat(e.target.value) || 30)))}
-                  className="w-12 bg-transparent text-right font-mono focus:outline-none"
-                  min="1"
-                />
-                <span className="text-zinc-400">hrs</span>
-              </div>
-            </div>
-            <div className="text-right">
-              <div className="text-[10px] text-zinc-500">Weekly earnings</div>
-              <div className="font-semibold tabular-nums neon-green">${totalEarnings.toFixed(0)}</div>
-            </div>
-          </div>
-        </div>
-
-        {/* ── HOURLY RATE — prominent editable card ── */}
-        <div
-          ref={rateCardRef}
-          className="rounded-2xl mb-4 px-5 py-4 flex items-center justify-between gap-4 transition-all duration-300"
-          style={{
-            background: highlightRate
-              ? `linear-gradient(135deg, ${accentColor}22 0%, ${accentColor}0A 100%)`
-              : 'rgba(255,255,255,0.04)',
-            border: highlightRate
-              ? `1.5px solid ${accentColor}`
-              : '1.5px solid rgba(255,255,255,0.08)',
-            boxShadow: highlightRate
-              ? `0 0 20px ${accentColor}40, 0 0 40px ${accentColor}20`
-              : 'none',
-          }}
-        >
-          <div>
-            <div className="text-xs uppercase tracking-[2px] text-zinc-400 mb-0.5">Your Hourly Rate</div>
-            <div className="text-xs text-zinc-600">Click the amount to edit your rate</div>
-          </div>
-          <div className="flex items-center gap-3">
-            <div
-              className="flex items-center rounded-xl px-4 py-2.5 gap-1 transition-all duration-300"
-              style={{
-                background: highlightRate ? `${accentColor}18` : 'rgba(0,0,0,0.4)',
-                border: highlightRate ? `1.5px solid ${accentColor}80` : '1.5px solid rgba(255,255,255,0.1)',
-              }}
-            >
-              <span className="text-zinc-300 text-xl font-light">$</span>
-              <input
-                ref={rateInputRef}
-                type="number"
-                value={hourlyRate}
-                onChange={(e) => setHourlyRate(Math.max(1, parseInt(e.target.value) || 0))}
-                className="w-20 bg-transparent text-right font-mono text-3xl font-bold focus:outline-none"
-                style={{ color: accentColor }}
-                min="1"
-              />
-              <span className="text-zinc-400 text-base">/hr</span>
-            </div>
+          <div className="text-right">
+            <div className="text-[10px] text-zinc-500">Weekly earnings</div>
+            <div className="font-semibold tabular-nums neon-green">${totalEarnings.toFixed(0)}</div>
           </div>
         </div>
 
         {/* Three modules side-by-side */}
-        <div className="grid grid-cols-3 gap-4">
+        <div className="grid grid-cols-3 gap-4 mb-4">
 
           {/* ── REAL TIME REWARDS ── */}
           <div className="glass rounded-3xl p-6 relative overflow-hidden">
@@ -370,28 +311,79 @@ export function Rewards({ totalHours, elapsedSeconds, isClockedIn, theme = 'gree
             <div className="text-[10px] text-zinc-600 mt-1.5 text-right">{Math.round(paycheckProgress)}% of pay cycle</div>
           </div>
         </div>
-      </div>
 
-      {/* ═══════════════════════════════════════════
-          PTO VAULT
-          ═══════════════════════════════════════════ */}
-      <div className="glass rounded-3xl p-6">
-        <div className="flex items-center justify-between">
-          <div>
-            <div className="text-lg font-semibold neon-green uppercase tracking-[2px] mb-1">PTO Vault</div>
-            <div className="flex items-baseline gap-2">
-              <span className="text-3xl font-bold neon-green tabular-nums">{accruedPTO.toFixed(3)}</span>
-              <span className="text-lg text-zinc-400">hrs</span>
+        {/* ── HOURLY RATE + PTO VAULT — side by side below the 3 modules ── */}
+        <div className="grid grid-cols-2 gap-4 mt-4">
+
+          {/* HOURLY RATE */}
+          <div
+            ref={rateCardRef}
+            className="rounded-2xl px-5 py-4 flex flex-col gap-3 transition-all duration-300"
+            style={{
+              background: highlightRate
+                ? `linear-gradient(135deg, ${accentColor}22 0%, ${accentColor}0A 100%)`
+                : 'rgba(255,255,255,0.04)',
+              border: highlightRate
+                ? `1.5px solid ${accentColor}`
+                : '1.5px solid rgba(255,255,255,0.08)',
+              boxShadow: highlightRate
+                ? `0 0 20px ${accentColor}40, 0 0 40px ${accentColor}20`
+                : 'none',
+            }}
+          >
+            <div>
+              <div className="text-xs uppercase tracking-[2px] text-zinc-400 mb-0.5">Your Hourly Rate</div>
+              <div className="text-xs text-zinc-600">Click the amount to edit your rate</div>
             </div>
-            <div className="text-xs text-zinc-500 mt-1">
-              Accruing 1 hr per {(1 / ptoAccrualRate).toFixed(0)} hrs worked
+            <div
+              className="flex items-center rounded-xl px-4 py-2.5 gap-1 transition-all duration-300"
+              style={{
+                background: highlightRate ? `${accentColor}18` : 'rgba(0,0,0,0.4)',
+                border: highlightRate ? `1.5px solid ${accentColor}80` : '1.5px solid rgba(255,255,255,0.1)',
+              }}
+            >
+              <span className="text-zinc-300 text-xl font-light">$</span>
+              <input
+                ref={rateInputRef}
+                type="number"
+                value={hourlyRate}
+                onChange={(e) => setHourlyRate(Math.max(1, parseInt(e.target.value) || 0))}
+                className="w-full bg-transparent text-right font-mono text-3xl font-bold focus:outline-none"
+                style={{ color: accentColor }}
+                min="1"
+              />
+              <span className="text-zinc-400 text-base">/hr</span>
             </div>
           </div>
-          <div className="text-right">
-            <div className="text-xs text-zinc-500 mb-1">Projected annual PTO</div>
-            <div className="text-2xl font-semibold neon-green">{(2080 * ptoAccrualRate).toFixed(1)} hrs</div>
-            <div className="text-xs text-zinc-600 mt-0.5">{(2080 * ptoAccrualRate / 8).toFixed(1)} days / year</div>
+
+          {/* PTO VAULT */}
+          <div className="rounded-2xl px-5 py-4 flex flex-col gap-3 transition-all duration-300"
+            style={{ background: 'rgba(255,255,255,0.04)', border: '1.5px solid rgba(255,255,255,0.08)' }}
+          >
+            <div>
+              <div className="text-xs uppercase tracking-[2px] text-zinc-400 mb-0.5">PTO Vault</div>
+              <div className="flex items-baseline gap-1.5">
+                <span className="text-3xl font-bold neon-green tabular-nums">{accruedPTO.toFixed(3)}</span>
+                <span className="text-sm text-zinc-400">hrs</span>
+              </div>
+              <div className="text-xs text-zinc-600 mt-0.5">{(2080 * ptoAccrualRate).toFixed(1)} hrs projected / yr</div>
+            </div>
+            <div>
+              <div className="text-xs text-zinc-500 mb-1.5">Accrual rate</div>
+              <div className="flex items-center bg-zinc-900 rounded-xl px-3 py-1.5 gap-1">
+                <span className="text-zinc-400 text-xs">1 hr per</span>
+                <input
+                  type="number"
+                  value={(1 / ptoAccrualRate).toFixed(0)}
+                  onChange={(e) => setPtoAccrualRate(Math.max(0.001, 1 / Math.max(1, parseFloat(e.target.value) || 30)))}
+                  className="w-12 bg-transparent text-right font-mono text-sm focus:outline-none text-white"
+                  min="1"
+                />
+                <span className="text-zinc-400 text-xs">hrs worked</span>
+              </div>
+            </div>
           </div>
+
         </div>
       </div>
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -717,3 +717,75 @@ button, [role="button"] {
 [data-theme="cyan"] .border-emerald-500\/30 { border-color: rgba(81,254,254,0.3) !important; }
 [data-theme="pink"] .border-emerald-500\/30 { border-color: rgba(254,81,215,0.3) !important; }
 [data-theme="purple"] .border-emerald-500\/30 { border-color: rgba(155,81,254,0.3) !important; }
+
+/* ============================================
+   OVERTIME OVERDRIVE MODE — Gold Electric Theme
+   Activates after 8 hours via data-overdrive="true"
+   ============================================ */
+
+[data-overdrive="true"] {
+  --accent-color: #FFD700;
+  --accent-color-rgb: 255, 215, 0;
+  --accent-color-dim: rgba(255, 215, 0, 0.15);
+}
+
+[data-overdrive="true"] .glass-btn-green,
+[data-overdrive="true"] .glass-btn-green:hover {
+  background: #FFD700;
+  color: #000;
+  border-color: rgba(255, 215, 0, 0.6);
+}
+
+@keyframes overdrive-glow-pulse {
+  0%, 100% {
+    box-shadow:
+      0 20px 60px -15px rgba(0, 0, 0, 0.75),
+      inset 0 2px 0 rgba(255, 255, 255, 0.45),
+      inset 0 -2px 0 rgba(0, 0, 0, 0.3),
+      0 0 12px rgba(255, 215, 0, 0.2),
+      0 0 30px rgba(255, 165, 0, 0.1);
+  }
+  50% {
+    box-shadow:
+      0 20px 60px -15px rgba(0, 0, 0, 0.75),
+      inset 0 2px 0 rgba(255, 255, 255, 0.45),
+      inset 0 -2px 0 rgba(0, 0, 0, 0.3),
+      0 0 30px rgba(255, 215, 0, 0.55),
+      0 0 80px rgba(255, 165, 0, 0.3),
+      0 0 120px rgba(255, 215, 0, 0.1);
+  }
+}
+
+@keyframes overdrive-border-flicker {
+  0%, 100% { border-color: rgba(255, 215, 0, 0.18); }
+  20%       { border-color: rgba(255, 215, 0, 0.55); }
+  40%       { border-color: rgba(255, 165, 0, 0.35); }
+  60%       { border-color: rgba(255, 215, 0, 0.75); }
+  80%       { border-color: rgba(255, 200, 0, 0.45); }
+}
+
+[data-overdrive="true"] .glass {
+  animation: overdrive-glow-pulse 2.4s ease-in-out infinite,
+             overdrive-border-flicker 3.2s ease-in-out infinite;
+}
+
+[data-overdrive="true"] .ta-navbar {
+  background: #080600;
+  border-bottom-color: rgba(255, 215, 0, 0.25);
+  box-shadow: 0 2px 20px rgba(255, 215, 0, 0.1);
+}
+
+[data-overdrive="true"] .ta-sidebar {
+  background: #080600;
+  border-right-color: rgba(255, 215, 0, 0.2);
+}
+
+[data-overdrive="true"] .ta-nav-btn.active {
+  box-shadow: inset 3px 0 0 #FFD700;
+  background: rgba(255, 215, 0, 0.08);
+}
+
+[data-overdrive="true"] .crystal-progress-fill {
+  background: linear-gradient(90deg, #FFA500, #FFD700, #FFEC6E);
+  box-shadow: 0 0 12px rgba(255, 215, 0, 0.7), 0 0 24px rgba(255, 165, 0, 0.4);
+}


### PR DESCRIPTION
Implements all changes requested in issue #66:

- Real Time Rewards moved to top of sidebar
- RTR content rearranged with better spacing
- This Pay Period expanded with earnings and progress bar
- Removed green outline from welcome toast
- Hourly Rate module moved below reward modules
- PTO Vault side-by-side with Hourly Rate
- PTO accrual rate editing inside PTO Vault
- Overtime Overdrive Mode (gold electric theme after 8h)

Closes #66

Generated with [Claude Code](https://claude.ai/code)