### PR TITLE
fix: resolve python3 not found on Railway deploy

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -2,6 +2,6 @@
 buildCommand = "sh build.sh"
 
 [deploy]
-startCommand = "bash -c 'export PATH=/root/.local/share/mise/shims:$PATH && cd backend && python3 init_db.py && gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT'"
+startCommand = "bash -c 'export PATH=$(ls -d /root/.local/share/mise/installs/python/*/bin | head -1):/root/.local/share/mise/shims:$PATH && cd backend && python3 init_db.py && gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT'"
 healthcheckPath = "/api/health"
 restartPolicyType = "on_failure"


### PR DESCRIPTION
Fixes #73

The deploy start command in `railway.toml` was exporting the mise shims directory to PATH, but the Python binary is not accessible via shims in the Railway runtime container. The fix dynamically resolves the actual Python binary directory using a glob over the mise installs path.

Generated with [Claude Code](https://claude.ai/code)