### PR TITLE
fix: resolve Railway deploy failure — python3 not found in runtime container

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bash -c 'export PATH=/root/.local/share/mise/shims:$PATH && cd backend && gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT'
+web: bash -c 'export PATH=/root/.local/share/mise/shims:$PATH && cd backend && python3 init_db.py && gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT'

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+export PATH=/root/.local/share/mise/shims:$PATH
+cd backend
+python3 init_db.py
+exec gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT


### PR DESCRIPTION
Fixes #77

## Summary

- Adds `start.sh` which Railpack prefers over its auto-generated start command
- Uses `/root/.local/share/mise/shims` (stable) instead of the brittle `ls -d ...installs/python/*/bin` glob that fails when Python isn't at that path
- Adds missing `python3 init_db.py` step to both `start.sh` and `Procfile` so DB tables are created on startup

Generated with [Claude Code](https://claude.ai/code)