### PR TITLE
fix: use correct mise paths in Railway deploy command

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bash -c 'export PATH=/root/.local/share/mise/shims:$PATH && cd backend && python3 init_db.py && gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT'
+web: bash start.sh

--- a/railway.toml
+++ b/railway.toml
@@ -2,6 +2,6 @@
 buildCommand = "sh build.sh"
 
 [deploy]
-startCommand = "bash -c 'export PATH=$(ls -d /root/.local/share/mise/installs/python/*/bin | head -1):/root/.local/share/mise/shims:$PATH && cd backend && python3 init_db.py && gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT'"
+startCommand = "bash start.sh"
 healthcheckPath = "/api/health"
 restartPolicyType = "on_failure"

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-export PATH=/root/.local/share/mise/shims:$PATH
+export PATH=/mise/shims:$PATH
 cd backend
 python3 init_db.py
 exec gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT


### PR DESCRIPTION
Fixes #79

Railway's Railpack runtime puts mise at `/mise`, not `/root/.local/share/mise`. The previous `startCommand` in `railway.toml` used a glob `ls` on the wrong path, causing PATH setup to fail silently and gunicorn/init_db.py to run with system Python which lacks psycopg2.

- `railway.toml`: simplify startCommand to `bash start.sh`
- `start.sh`: use `/mise/shims` (correct runtime path)
- `Procfile`: delegate to start.sh for consistency

Generated with [Claude Code](https://claude.ai/code)