### PR TITLE
fix: pin chromadb<0.5 and improve Railway build reliability

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,9 +2,8 @@ flask>=2.0.0
 flask-cors>=4.0.0
 psycopg2-binary>=2.9.0
 openai>=1.0.0
-chromadb>=0.4.0
+chromadb>=0.4.0,<0.5.0
 pypdf>=4.0.0
 python-docx>=1.1.0
-pytest>=8.0.0
 requests
 gunicorn>=21.0.0

--- a/build.sh
+++ b/build.sh
@@ -4,12 +4,13 @@ set -e
 echo "Building frontend..."
 cd frontend
 npm install
+export NODE_OPTIONS='--max-old-space-size=4096'
 npm run build
 cd ..
 
 echo "Installing backend dependencies..."
 cd backend
-pip install -r requirements.txt
+pip install --no-cache-dir -r requirements.txt
 cd ..
 
 echo "Done!"


### PR DESCRIPTION
Fixes #81

- Pin chromadb to >=0.4.0,<0.5.0 to avoid heavy onnxruntime/tokenizers deps in 0.5+ that can OOM Railway builds
- Remove pytest from production requirements (dev-only)
- Add NODE_OPTIONS memory flag to npm build
- Use pip install --no-cache-dir

Generated with [Claude Code](https://claude.ai/code)