### PR TITLE
fix: install Python deps into venv so they survive Railway multi-stage build

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,9 +2,8 @@ flask>=2.0.0
 flask-cors>=4.0.0
 psycopg2-binary>=2.9.0
 openai>=1.0.0
-chromadb>=0.4.0
+chromadb>=0.4.0,<0.5.0
 pypdf>=4.0.0
 python-docx>=1.1.0
-pytest>=8.0.0
 requests
 gunicorn>=21.0.0

--- a/build.sh
+++ b/build.sh
@@ -8,8 +8,7 @@ npm run build
 cd ..
 
 echo "Installing backend dependencies..."
-cd backend
-pip install -r requirements.txt
-cd ..
+python3 -m venv /app/venv
+/app/venv/bin/pip install --no-cache-dir -r backend/requirements.txt
 
 echo "Done!"

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@ set -e
 echo "Building frontend..."
 cd frontend
 npm install
+export NODE_OPTIONS='--max-old-space-size=4096'
 npm run build
 cd ..
 

--- a/start.sh
+++ b/start.sh
@@ -2,5 +2,5 @@
 set -e
 export PATH=/mise/shims:$PATH
 cd backend
-python3 init_db.py
-exec gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT
+/app/venv/bin/python3 init_db.py
+exec /app/venv/bin/gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT


### PR DESCRIPTION
Fixes #81

**Root cause:** `pip install` in `build.sh` was writing packages to the build container's system Python, which is not copied to the runtime container. At startup, Python couldn't find any packages (including psycopg2).

**Fix:** Create a virtualenv at `/app/venv` (inside /app which IS copied to runtime) and install all deps there. Update start.sh to use the venv's Python and gunicorn.

**Also:** cap chromadb<0.5.0 to avoid heavy onnxruntime deps, remove pytest from production requirements.

Generated with [Claude Code](https://claude.ai/code)