### PR TITLE
fix: install Python deps into venv so they survive Railway build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,8 +9,7 @@ npm run build
 cd ..
 
 echo "Installing backend dependencies..."
-cd backend
-pip install --no-cache-dir -r requirements.txt
-cd ..
+python3 -m venv /app/venv
+/app/venv/bin/pip install --no-cache-dir -r backend/requirements.txt
 
 echo "Done!"

--- a/start.sh
+++ b/start.sh
@@ -2,5 +2,5 @@
 set -e
 export PATH=/mise/shims:$PATH
 cd backend
-python3 init_db.py
-exec gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT
+/app/venv/bin/python3 init_db.py
+exec /app/venv/bin/gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT


### PR DESCRIPTION
Fixes #81

Install backend Python dependencies into `/app/venv` (a virtualenv inside /app) so they are copied to the runtime container. Plain `pip install` wrote to the build container's system Python which is discarded after the build stage, causing `ModuleNotFoundError: No module named 'psycopg2'` at startup.

Generated with [Claude Code](https://claude.ai/code)) • [`claude/issue-81-20260424-0258`](https://github.com/GiTD67/SwiftShift/tree/claude/issue-81-20260424-0258