### PR TITLE
feat: persist time tracking data to backend, add timesheets and PTO APIs

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -5,7 +5,7 @@ from flask import Flask, jsonify, send_from_directory, request
 from flask_cors import CORS
 
 from db import get_db  # noqa: F401  # ensure db module is loaded
-from routes import health_bp, employees_bp, time_entries_bp, clock_sessions_bp, users_bp, grok_bp, jobs_bp
+from routes import health_bp, employees_bp, time_entries_bp, clock_sessions_bp, users_bp, grok_bp, jobs_bp, timesheets_bp, pto_bp
 from auth import bp as auth_bp
 
 frontend_dir = os.path.join(os.path.dirname(__file__), "..", "frontend", "dist")
@@ -54,6 +54,8 @@ app.register_blueprint(auth_bp)
 app.register_blueprint(users_bp)
 app.register_blueprint(grok_bp)
 app.register_blueprint(jobs_bp)
+app.register_blueprint(timesheets_bp)
+app.register_blueprint(pto_bp)
 
 
 # --- Frontend SPA ---

--- a/backend/app.py
+++ b/backend/app.py
@@ -5,7 +5,7 @@ from flask import Flask, jsonify, send_from_directory, request
 from flask_cors import CORS
 
 from db import get_db  # noqa: F401  # ensure db module is loaded
-from routes import health_bp, employees_bp, time_entries_bp, clock_sessions_bp, users_bp, grok_bp, jobs_bp, timesheets_bp, pto_bp
+from routes import health_bp, employees_bp, time_entries_bp, clock_sessions_bp, users_bp, grok_bp, jobs_bp, timesheet_submissions_bp, timesheets_bp, pto_bp
 from auth import bp as auth_bp
 
 frontend_dir = os.path.join(os.path.dirname(__file__), "..", "frontend", "dist")
@@ -54,6 +54,7 @@ app.register_blueprint(auth_bp)
 app.register_blueprint(users_bp)
 app.register_blueprint(grok_bp)
 app.register_blueprint(jobs_bp)
+app.register_blueprint(timesheet_submissions_bp)
 app.register_blueprint(timesheets_bp)
 app.register_blueprint(pto_bp)
 

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -42,7 +42,7 @@ def _ensure_users_table():
             """
         )
         # Add columns if upgrading from older schema
-        for col in ("job_role", "manager_name"):
+        for col in ("job_role", "manager_name", "streak_last_date"):
             try:
                 db.execute(f"ALTER TABLE users ADD COLUMN {col} TEXT")
                 db.commit()
@@ -57,6 +57,17 @@ def _ensure_users_table():
                 db.commit()
             except Exception:
                 pass  # column already exists or other error, ignore
+        for col in ("hourly_rate", "pto_accrual_rate"):
+            try:
+                db.execute(f"ALTER TABLE users ADD COLUMN {col} REAL")
+                db.commit()
+            except Exception:
+                pass  # column already exists or other error, ignore
+        try:
+            db.execute("ALTER TABLE users ADD COLUMN streak_count INTEGER DEFAULT 0")
+            db.commit()
+        except Exception:
+            pass  # column already exists or other error, ignore
 
 
 _ensure_users_table()
@@ -130,13 +141,62 @@ def _ensure_clock_sessions_table():
               clock_in TEXT,
               clock_out TEXT,
               duration_minutes INTEGER,
+              break_minutes INTEGER DEFAULT 0,
+              notes TEXT
+            )
+            """
+        )
+        try:
+            db.execute("ALTER TABLE clock_sessions ADD COLUMN break_minutes INTEGER DEFAULT 0")
+            db.commit()
+        except Exception:
+            pass  # column already exists
+
+
+_ensure_clock_sessions_table()
+
+
+def _ensure_timesheets_table():
+    with get_db() as db:
+        db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS timesheets (
+              id SERIAL PRIMARY KEY,
+              employee_id INTEGER NOT NULL,
+              pay_period_start TEXT NOT NULL,
+              pay_period_end TEXT NOT NULL,
+              total_hours REAL DEFAULT 0,
+              regular_hours REAL DEFAULT 0,
+              overtime_hours REAL DEFAULT 0,
+              break_minutes INTEGER DEFAULT 0,
+              status TEXT DEFAULT 'pending',
+              submitted_at TEXT,
+              approved_at TEXT,
+              approved_by INTEGER,
               notes TEXT
             )
             """
         )
 
 
-_ensure_clock_sessions_table()
+_ensure_timesheets_table()
+
+
+def _ensure_pto_balances_table():
+    with get_db() as db:
+        db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS pto_balances (
+              id SERIAL PRIMARY KEY,
+              employee_id INTEGER NOT NULL UNIQUE,
+              balance_hours REAL DEFAULT 0,
+              last_updated TEXT
+            )
+            """
+        )
+
+
+_ensure_pto_balances_table()
 
 
 @bp.route("/signup", methods=["POST"])
@@ -152,7 +212,7 @@ def signup():
     with get_db() as db:
         try:
             user = db.execute(
-                "INSERT INTO users (first_name, last_name, email, password_hash, is_fulltime) VALUES (?, ?, ?, ?, 1) RETURNING id, first_name, last_name, email, job_role, manager_name, is_fulltime, pay, salary",
+                "INSERT INTO users (first_name, last_name, email, password_hash, is_fulltime) VALUES (?, ?, ?, ?, 1) RETURNING id, first_name, last_name, email, job_role, manager_name, is_fulltime, pay, salary, hourly_rate, pto_accrual_rate, streak_count, streak_last_date",
                 (first_name, last_name, email, pw_hash),
             ).fetchone()
         except Exception as e:
@@ -183,4 +243,8 @@ def signin():
         "is_fulltime": row.get("is_fulltime", 1),
         "pay": row.get("pay"),
         "salary": row.get("salary"),
+        "hourly_rate": row.get("hourly_rate"),
+        "pto_accrual_rate": row.get("pto_accrual_rate"),
+        "streak_count": row.get("streak_count", 0),
+        "streak_last_date": row.get("streak_last_date"),
     })

--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -72,6 +72,17 @@ tables = [
     )
     """,
     """
+    CREATE TABLE IF NOT EXISTS timesheet_submissions (
+      id SERIAL PRIMARY KEY,
+      user_id INTEGER NOT NULL,
+      period_start TEXT NOT NULL,
+      period_end TEXT NOT NULL,
+      total_hours REAL NOT NULL,
+      submitted_at TEXT NOT NULL DEFAULT (NOW()::text),
+      UNIQUE (user_id, period_start)
+    )
+    """,
+    """
     CREATE TABLE IF NOT EXISTS timesheets (
       id SERIAL PRIMARY KEY,
       employee_id INTEGER NOT NULL,

--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -22,7 +22,11 @@ tables = [
       manager_name TEXT,
       is_fulltime INTEGER DEFAULT 1,
       pay REAL,
-      salary REAL
+      salary REAL,
+      hourly_rate REAL,
+      pto_accrual_rate REAL,
+      streak_count INTEGER DEFAULT 0,
+      streak_last_date TEXT
     )
     """,
     """
@@ -39,6 +43,7 @@ tables = [
       clock_in TEXT,
       clock_out TEXT,
       duration_minutes INTEGER,
+      break_minutes INTEGER DEFAULT 0,
       notes TEXT
     )
     """,
@@ -64,6 +69,31 @@ tables = [
       date_expiry TEXT,
       salary TEXT,
       location TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS timesheets (
+      id SERIAL PRIMARY KEY,
+      employee_id INTEGER NOT NULL,
+      pay_period_start TEXT NOT NULL,
+      pay_period_end TEXT NOT NULL,
+      total_hours REAL DEFAULT 0,
+      regular_hours REAL DEFAULT 0,
+      overtime_hours REAL DEFAULT 0,
+      break_minutes INTEGER DEFAULT 0,
+      status TEXT DEFAULT 'pending',
+      submitted_at TEXT,
+      approved_at TEXT,
+      approved_by INTEGER,
+      notes TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS pto_balances (
+      id SERIAL PRIMARY KEY,
+      employee_id INTEGER NOT NULL UNIQUE,
+      balance_hours REAL DEFAULT 0,
+      last_updated TEXT
     )
     """,
 ]

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -5,5 +5,7 @@ from .clock_sessions import bp as clock_sessions_bp
 from .users import bp as users_bp
 from .grok import bp as grok_bp
 from .jobs import bp as jobs_bp
+from .timesheets import bp as timesheets_bp
+from .pto import bp as pto_bp
 
-__all__ = ["health_bp", "employees_bp", "time_entries_bp", "clock_sessions_bp", "users_bp", "grok_bp", "jobs_bp"]
+__all__ = ["health_bp", "employees_bp", "time_entries_bp", "clock_sessions_bp", "users_bp", "grok_bp", "jobs_bp", "timesheets_bp", "pto_bp"]

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -5,7 +5,8 @@ from .clock_sessions import bp as clock_sessions_bp
 from .users import bp as users_bp
 from .grok import bp as grok_bp
 from .jobs import bp as jobs_bp
+from .timesheet_submissions import bp as timesheet_submissions_bp
 from .timesheets import bp as timesheets_bp
 from .pto import bp as pto_bp
 
-__all__ = ["health_bp", "employees_bp", "time_entries_bp", "clock_sessions_bp", "users_bp", "grok_bp", "jobs_bp", "timesheets_bp", "pto_bp"]
+__all__ = ["health_bp", "employees_bp", "time_entries_bp", "clock_sessions_bp", "users_bp", "grok_bp", "jobs_bp", "timesheet_submissions_bp", "timesheets_bp", "pto_bp"]

--- a/backend/routes/clock_sessions.py
+++ b/backend/routes/clock_sessions.py
@@ -43,13 +43,16 @@ def clock_in():
     return jsonify(dict(row)), 201
 
 
-def _compute_session_duration(clock_in_str: str) -> int:
+def _compute_session_duration(clock_in_str: str, break_minutes: int = 0) -> int:
     clock_in = datetime.fromisoformat(clock_in_str)
-    return int((datetime.utcnow() - clock_in).total_seconds() / 60)
+    total = int((datetime.utcnow() - clock_in).total_seconds() / 60)
+    return max(0, total - break_minutes)
 
 
 @bp.route("/api/clock-sessions/<int:session_id>", methods=["PUT"])
 def clock_out(session_id):
+    data = request.get_json() or {}
+    break_minutes = int(data.get("break_minutes", 0))
     now = datetime.utcnow().isoformat()
     with get_db() as db:
         row = db.execute("SELECT * FROM clock_sessions WHERE id = ?", (session_id,)).fetchone()
@@ -57,10 +60,10 @@ def clock_out(session_id):
             return jsonify({"error": "not found"}), 404
         if row["clock_out"]:
             return jsonify({"error": "already clocked out"}), 400
-        duration = _compute_session_duration(row["clock_in"])
+        duration = _compute_session_duration(row["clock_in"], break_minutes)
         db.execute(
-            "UPDATE clock_sessions SET clock_out = ?, duration_minutes = ? WHERE id = ?",
-            (now, duration, session_id),
+            "UPDATE clock_sessions SET clock_out = ?, duration_minutes = ?, break_minutes = ? WHERE id = ?",
+            (now, duration, break_minutes, session_id),
         )
         db.commit()
         row = db.execute("SELECT * FROM clock_sessions WHERE id = ?", (session_id,)).fetchone()

--- a/backend/routes/pto.py
+++ b/backend/routes/pto.py
@@ -1,0 +1,75 @@
+from datetime import datetime
+
+from flask import Blueprint, jsonify, request
+
+from db import get_db
+
+bp = Blueprint("pto", __name__)
+
+
+@bp.route("/api/pto/<int:employee_id>", methods=["GET"])
+def get_pto_balance(employee_id):
+    with get_db() as db:
+        row = db.execute(
+            "SELECT * FROM pto_balances WHERE employee_id = %s", (employee_id,)
+        ).fetchone()
+    if not row:
+        return jsonify({"employee_id": employee_id, "balance_hours": 0.0, "last_updated": None})
+    return jsonify(dict(row))
+
+
+@bp.route("/api/pto/<int:employee_id>/accrue", methods=["POST"])
+def accrue_pto(employee_id):
+    data = request.get_json() or {}
+    hours = float(data.get("hours", 0))
+    if hours <= 0:
+        return jsonify({"error": "hours must be positive"}), 400
+    now = datetime.utcnow().isoformat()
+    with get_db() as db:
+        existing = db.execute(
+            "SELECT * FROM pto_balances WHERE employee_id = %s", (employee_id,)
+        ).fetchone()
+        if existing:
+            new_balance = (existing["balance_hours"] or 0.0) + hours
+            db.execute(
+                "UPDATE pto_balances SET balance_hours = %s, last_updated = %s WHERE employee_id = %s",
+                (new_balance, now, employee_id),
+            )
+        else:
+            db.execute(
+                "INSERT INTO pto_balances (employee_id, balance_hours, last_updated) VALUES (%s, %s, %s)",
+                (employee_id, hours, now),
+            )
+        db.commit()
+        row = db.execute(
+            "SELECT * FROM pto_balances WHERE employee_id = %s", (employee_id,)
+        ).fetchone()
+    return jsonify(dict(row))
+
+
+@bp.route("/api/pto/<int:employee_id>/adjust", methods=["POST"])
+def adjust_pto(employee_id):
+    data = request.get_json() or {}
+    if "balance_hours" not in data:
+        return jsonify({"error": "balance_hours required"}), 400
+    balance = float(data["balance_hours"])
+    now = datetime.utcnow().isoformat()
+    with get_db() as db:
+        existing = db.execute(
+            "SELECT id FROM pto_balances WHERE employee_id = %s", (employee_id,)
+        ).fetchone()
+        if existing:
+            db.execute(
+                "UPDATE pto_balances SET balance_hours = %s, last_updated = %s WHERE employee_id = %s",
+                (balance, now, employee_id),
+            )
+        else:
+            db.execute(
+                "INSERT INTO pto_balances (employee_id, balance_hours, last_updated) VALUES (%s, %s, %s)",
+                (employee_id, balance, now),
+            )
+        db.commit()
+        row = db.execute(
+            "SELECT * FROM pto_balances WHERE employee_id = %s", (employee_id,)
+        ).fetchone()
+    return jsonify(dict(row))

--- a/backend/routes/timesheet_submissions.py
+++ b/backend/routes/timesheet_submissions.py
@@ -1,0 +1,67 @@
+from flask import Blueprint, jsonify, request
+
+from db import get_db
+
+bp = Blueprint("timesheet_submissions", __name__)
+
+_TABLE_DDL = """
+CREATE TABLE IF NOT EXISTS timesheet_submissions (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL,
+  period_start TEXT NOT NULL,
+  period_end TEXT NOT NULL,
+  total_hours REAL NOT NULL,
+  submitted_at TEXT NOT NULL DEFAULT (NOW()::text),
+  UNIQUE (user_id, period_start)
+)
+"""
+
+
+def _ensure_table(db):
+    db.execute(_TABLE_DDL)
+
+
+@bp.route("/api/timesheet-submissions", methods=["GET"])
+def list_submissions():
+    user_id = request.args.get("user_id")
+    with get_db() as db:
+        _ensure_table(db)
+        if user_id:
+            rows = db.execute(
+                "SELECT * FROM timesheet_submissions WHERE user_id = ? ORDER BY period_start DESC",
+                (user_id,),
+            ).fetchall()
+        else:
+            rows = db.execute(
+                "SELECT * FROM timesheet_submissions ORDER BY period_start DESC"
+            ).fetchall()
+    return jsonify([dict(r) for r in rows])
+
+
+@bp.route("/api/timesheet-submissions", methods=["POST"])
+def create_submission():
+    data = request.get_json() or {}
+    user_id = data.get("user_id")
+    period_start = data.get("period_start")
+    period_end = data.get("period_end")
+    total_hours = data.get("total_hours")
+
+    if not all([user_id, period_start, period_end, total_hours is not None]):
+        return jsonify({"error": "user_id, period_start, period_end, and total_hours are required"}), 400
+
+    with get_db() as db:
+        _ensure_table(db)
+        row = db.execute(
+            """
+            INSERT INTO timesheet_submissions (user_id, period_start, period_end, total_hours)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT (user_id, period_start) DO UPDATE
+              SET period_end = EXCLUDED.period_end,
+                  total_hours = EXCLUDED.total_hours,
+                  submitted_at = NOW()::text
+            RETURNING *
+            """,
+            (user_id, period_start, period_end, total_hours),
+        ).fetchone()
+        db.commit()
+    return jsonify(dict(row)), 201

--- a/backend/routes/timesheets.py
+++ b/backend/routes/timesheets.py
@@ -1,0 +1,109 @@
+from datetime import datetime
+
+from flask import Blueprint, jsonify, request
+
+from db import get_db
+
+bp = Blueprint("timesheets", __name__)
+
+
+@bp.route("/api/timesheets", methods=["GET"])
+def list_timesheets():
+    employee_id = request.args.get("employee_id")
+    status = request.args.get("status")
+    with get_db() as db:
+        sql = "SELECT * FROM timesheets"
+        params = []
+        where = []
+        if employee_id:
+            where.append("employee_id = %s")
+            params.append(employee_id)
+        if status:
+            where.append("status = %s")
+            params.append(status)
+        if where:
+            sql += " WHERE " + " AND ".join(where)
+        sql += " ORDER BY submitted_at DESC"
+        rows = db.execute(sql, params or None).fetchall()
+    return jsonify([dict(r) for r in rows])
+
+
+@bp.route("/api/timesheets", methods=["POST"])
+def submit_timesheet():
+    data = request.get_json() or {}
+    employee_id = data.get("employee_id")
+    pay_period_start = data.get("pay_period_start")
+    pay_period_end = data.get("pay_period_end")
+    if not employee_id or not pay_period_start or not pay_period_end:
+        return jsonify({"error": "employee_id, pay_period_start, pay_period_end required"}), 400
+    now = datetime.utcnow().isoformat()
+    with get_db() as db:
+        existing = db.execute(
+            "SELECT id FROM timesheets WHERE employee_id = %s AND pay_period_start = %s",
+            (employee_id, pay_period_start),
+        ).fetchone()
+        if existing:
+            db.execute(
+                """UPDATE timesheets SET
+                   total_hours = %s, regular_hours = %s, overtime_hours = %s,
+                   break_minutes = %s, status = 'pending', submitted_at = %s
+                   WHERE id = %s""",
+                (
+                    data.get("total_hours", 0),
+                    data.get("regular_hours", 0),
+                    data.get("overtime_hours", 0),
+                    data.get("break_minutes", 0),
+                    now,
+                    existing["id"],
+                ),
+            )
+            db.commit()
+            row = db.execute("SELECT * FROM timesheets WHERE id = %s", (existing["id"],)).fetchone()
+        else:
+            row = db.execute(
+                """INSERT INTO timesheets
+                   (employee_id, pay_period_start, pay_period_end, total_hours, regular_hours,
+                    overtime_hours, break_minutes, status, submitted_at)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, 'pending', %s) RETURNING *""",
+                (
+                    employee_id,
+                    pay_period_start,
+                    pay_period_end,
+                    data.get("total_hours", 0),
+                    data.get("regular_hours", 0),
+                    data.get("overtime_hours", 0),
+                    data.get("break_minutes", 0),
+                    now,
+                ),
+            ).fetchone()
+            db.commit()
+    return jsonify(dict(row)), 201
+
+
+@bp.route("/api/timesheets/<int:ts_id>", methods=["GET"])
+def get_timesheet(ts_id):
+    with get_db() as db:
+        row = db.execute("SELECT * FROM timesheets WHERE id = %s", (ts_id,)).fetchone()
+    if not row:
+        return jsonify({"error": "not found"}), 404
+    return jsonify(dict(row))
+
+
+@bp.route("/api/timesheets/<int:ts_id>", methods=["PUT"])
+def update_timesheet(ts_id):
+    data = request.get_json() or {}
+    allowed = {"status", "approved_by", "notes"}
+    fields = {k: v for k, v in data.items() if k in allowed}
+    if not fields:
+        return jsonify({"error": "no updatable fields"}), 400
+    if fields.get("status") in ("approved", "rejected"):
+        fields["approved_at"] = datetime.utcnow().isoformat()
+    set_clause = ", ".join(f"{k} = %s" for k in fields)
+    values = list(fields.values()) + [ts_id]
+    with get_db() as db:
+        db.execute(f"UPDATE timesheets SET {set_clause} WHERE id = %s", values)
+        db.commit()
+        row = db.execute("SELECT * FROM timesheets WHERE id = %s", (ts_id,)).fetchone()
+    if not row:
+        return jsonify({"error": "not found"}), 404
+    return jsonify(dict(row))

--- a/backend/routes/users.py
+++ b/backend/routes/users.py
@@ -6,12 +6,13 @@ from db import get_db
 bp = Blueprint("users", __name__)
 
 
+_USER_FIELDS = "id, first_name, last_name, email, job_role, manager_name, is_fulltime, pay, salary, hourly_rate, pto_accrual_rate, streak_count, streak_last_date"
+
+
 @bp.route("/api/users", methods=["GET"])
 def list_users():
     with get_db() as db:
-        rows = db.execute(
-            "SELECT id, first_name, last_name, email, job_role, manager_name, is_fulltime, pay, salary FROM users ORDER BY id"
-        ).fetchall()
+        rows = db.execute(f"SELECT {_USER_FIELDS} FROM users ORDER BY id").fetchall()
     return jsonify([dict(r) for r in rows])
 
 
@@ -45,7 +46,7 @@ def create_user():
 def get_user(uid):
     with get_db() as db:
         row = db.execute(
-            "SELECT id, first_name, last_name, email, job_role, manager_name, is_fulltime, pay, salary FROM users WHERE id = ?",
+            f"SELECT {_USER_FIELDS} FROM users WHERE id = ?",
             (uid,),
         ).fetchone()
     if not row:
@@ -56,7 +57,8 @@ def get_user(uid):
 @bp.route("/api/users/<int:uid>", methods=["PUT"])
 def update_user(uid):
     data = request.get_json() or {}
-    allowed = {"job_role", "manager_name", "is_fulltime", "pay", "salary"}
+    allowed = {"job_role", "manager_name", "is_fulltime", "pay", "salary",
+               "hourly_rate", "pto_accrual_rate", "streak_count", "streak_last_date"}
     fields = {k: v for k, v in data.items() if k in allowed}
     if not fields:
         return jsonify({"error": "no updatable fields provided"}), 400
@@ -65,10 +67,7 @@ def update_user(uid):
     with get_db() as db:
         db.execute(f"UPDATE users SET {set_clause} WHERE id = ?", values)
         db.commit()
-        row = db.execute(
-            "SELECT id, first_name, last_name, email, job_role, manager_name, is_fulltime, pay, salary FROM users WHERE id = ?",
-            (uid,),
-        ).fetchone()
+        row = db.execute(f"SELECT {_USER_FIELDS} FROM users WHERE id = ?", (uid,)).fetchone()
     if not row:
         return jsonify({"error": "not found"}), 404
     return jsonify(dict(row))

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -497,6 +497,22 @@ function TimesheetView({ user }: { user: any }) {
       confetti({ particleCount: 150, spread: 90, origin: { y: 0.5 } })
       setTimeout(() => confetti({ particleCount: 100, spread: 70, angle: 75, origin: { x: 0.2, y: 0.6 } }), 150)
       setTimeout(() => confetti({ particleCount: 100, spread: 70, angle: 105, origin: { x: 0.8, y: 0.6 } }), 300)
+
+      // Persist timesheet submission to backend
+      if (user?.id) {
+        fetch(`${API_BASE}/api/timesheets`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            employee_id: user.id,
+            pay_period_start: start.toISOString().slice(0, 10),
+            pay_period_end: end.toISOString().slice(0, 10),
+            total_hours: totalHours,
+            regular_hours: regularHours,
+            overtime_hours: overtimeHours,
+          }),
+        }).catch(() => {})
+      }
     }
   }
 
@@ -1320,6 +1336,7 @@ export default function App() {
   // Main app
   const [activeView, setActiveView] = useState<View>('clock')
   const [clockHourlyRate, setClockHourlyRate] = useState<number>(() => {
+    if (user?.hourly_rate) return Number(user.hourly_rate)
     const saved = localStorage.getItem('swiftshift-hourly-rate')
     if (saved) return parseFloat(saved)
     const salary = Number(user?.salary) || 0
@@ -1552,14 +1569,19 @@ export default function App() {
   // Tracks which reminder thresholds have already fired this clock session (reset on clock-in)
   const breakReminderFiredRef = useRef<Set<string>>(new Set())
 
-  // Daily streak counter (gamified punctuality)
+  // Daily streak counter (gamified punctuality) — prefer DB value from user profile
   const [streak, setStreak] = useState<number>(() => {
+    if (user?.streak_count != null) return Number(user.streak_count)
     const saved = localStorage.getItem('streak')
     return saved ? parseInt(saved, 10) : 0
   })
   const [lastStreakDate, setLastStreakDate] = useState<string>(() => {
+    if (user?.streak_last_date) return user.streak_last_date
     return localStorage.getItem('lastStreakDate') || ''
   })
+
+  // Active DB session ID (set on clock-in, used for clock-out PUT)
+  const [activeSessionId, setActiveSessionId] = useState<number | null>(null)
 
   // Restore clock state from DB on login / user change
   useEffect(() => {
@@ -1602,12 +1624,14 @@ export default function App() {
             todayMs += activeElapsedMs
           }
           setClockInAt(clockInDate)
+          setActiveSessionId(active.id)
           setBreakStartedAt(null)
           setBreakType(null)
           setBreakMsAccum(0)
           setPaidBreakMsAccum(0)
         } else {
           setClockInAt(null)
+          setActiveSessionId(null)
         }
 
         setTodayWorkedMs(todayMs)
@@ -1753,6 +1777,13 @@ export default function App() {
         setLastStreakDate(todayStr)
         localStorage.setItem('streak', String(newStreak))
         localStorage.setItem('lastStreakDate', todayStr)
+        if (user?.id) {
+          fetch(`${API_BASE}/api/users/${user.id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ streak_count: newStreak, streak_last_date: todayStr }),
+          }).catch(() => {})
+        }
 
         // Streak milestone celebrations
         if ([5, 10, 20, 30, 50].includes(newStreak)) {
@@ -1797,6 +1828,18 @@ export default function App() {
         setShockwaveActive(false)
         setRipplePos(null)
       }, 900)
+
+      // Persist clock-in to backend
+      if (user?.id) {
+        fetch(`${API_BASE}/api/clock-sessions`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ employee_id: user.id }),
+        })
+          .then(r => r.ok ? r.json() : null)
+          .then(session => { if (session?.id) setActiveSessionId(session.id) })
+          .catch(() => {})
+      }
     }
   }
 
@@ -1893,6 +1936,26 @@ export default function App() {
       setLootPtoHours(Math.round(hoursWorked * ptoAccrualRate * 100) / 100)
       setLootDurationMin(Math.round(session / 60000))
       setShowLootDrop(true)
+
+      // Persist clock-out to backend
+      const unpaidBreakMins = Math.round(unpaidAccum / 60000)
+      if (user?.id && activeSessionId) {
+        fetch(`${API_BASE}/api/clock-sessions/${activeSessionId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ break_minutes: unpaidBreakMins }),
+        }).catch(() => {})
+        setActiveSessionId(null)
+      }
+      // Accrue PTO balance in DB
+      const ptoEarned = Math.round(hoursWorked * ptoAccrualRate * 10000) / 10000
+      if (user?.id && ptoEarned > 0) {
+        fetch(`${API_BASE}/api/pto/${user.id}/accrue`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ hours: ptoEarned }),
+        }).catch(() => {})
+      }
     }
   }
 
@@ -2548,7 +2611,16 @@ export default function App() {
               theme={theme}
               user={user}
               highlightRate={highlightRate}
-              onRateChange={(rate) => setClockHourlyRate(rate)}
+              onRateChange={(rate) => {
+                setClockHourlyRate(rate)
+                if (user?.id) {
+                  fetch(`${API_BASE}/api/users/${user.id}`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ hourly_rate: rate }),
+                  }).catch(() => {})
+                }
+              }}
             />
           )}
           {activeView === 'admin' && (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -498,7 +498,17 @@ function TimesheetView({ user }: { user: any }) {
       setTimeout(() => confetti({ particleCount: 100, spread: 70, angle: 75, origin: { x: 0.2, y: 0.6 } }), 150)
       setTimeout(() => confetti({ particleCount: 100, spread: 70, angle: 105, origin: { x: 0.8, y: 0.6 } }), 300)
 
-      // Persist timesheet submission to backend
+      // Persist timesheet submission to legacy and new backend endpoints
+      fetch(`${API_BASE}/api/timesheet-submissions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          user_id: user?.id,
+          period_start: start.toISOString().slice(0, 10),
+          period_end: end.toISOString().slice(0, 10),
+          total_hours: totalHours,
+        }),
+      }).catch(() => {})
       if (user?.id) {
         fetch(`${API_BASE}/api/timesheets`, {
           method: 'POST',


### PR DESCRIPTION
Addresses the core data persistence gaps from issue #84:

- Clock-in/out now syncs to `/api/clock-sessions` so session data survives page refresh
- Break minutes stored in DB; unpaid breaks deducted from `duration_minutes`
- Timesheet submit button POSTs to new `/api/timesheets` endpoint
- Manager can approve/reject via `PUT /api/timesheets/:id`
- PTO balance accumulated in `pto_balances` table on every clock-out
- User preferences (hourly rate, streak) persisted to `users` table instead of only localStorage

Closes #84

Generated with [Claude Code](https://claude.ai/code)