### PR TITLE
feat: persist break minutes and user prefs to backend

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -57,6 +57,24 @@ def _ensure_users_table():
                 db.commit()
             except Exception:
                 pass  # column already exists or other error, ignore
+        for col_def in (
+            "hourly_rate REAL DEFAULT 20.0",
+            "pto_accrual_rate REAL DEFAULT 0.0385",
+            "streak_count INTEGER DEFAULT 0",
+            "streak_last_date TEXT",
+        ):
+            col = col_def.split()[0]
+            try:
+                db.execute(f"ALTER TABLE users ADD COLUMN {col_def}")
+                db.commit()
+            except Exception:
+                pass  # column already exists
+        # Add break_minutes to clock_sessions if upgrading from older schema
+        try:
+            db.execute("ALTER TABLE clock_sessions ADD COLUMN break_minutes INTEGER DEFAULT 0")
+            db.commit()
+        except Exception:
+            pass
 
 
 _ensure_users_table()
@@ -152,7 +170,7 @@ def signup():
     with get_db() as db:
         try:
             user = db.execute(
-                "INSERT INTO users (first_name, last_name, email, password_hash, is_fulltime) VALUES (?, ?, ?, ?, 1) RETURNING id, first_name, last_name, email, job_role, manager_name, is_fulltime, pay, salary",
+                "INSERT INTO users (first_name, last_name, email, password_hash, is_fulltime) VALUES (?, ?, ?, ?, 1) RETURNING id, first_name, last_name, email, job_role, manager_name, is_fulltime, pay, salary, hourly_rate, pto_accrual_rate, streak_count, streak_last_date",
                 (first_name, last_name, email, pw_hash),
             ).fetchone()
         except Exception as e:
@@ -183,4 +201,8 @@ def signin():
         "is_fulltime": row.get("is_fulltime", 1),
         "pay": row.get("pay"),
         "salary": row.get("salary"),
+        "hourly_rate": row.get("hourly_rate"),
+        "pto_accrual_rate": row.get("pto_accrual_rate"),
+        "streak_count": row.get("streak_count"),
+        "streak_last_date": row.get("streak_last_date"),
     })

--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -22,7 +22,11 @@ tables = [
       manager_name TEXT,
       is_fulltime INTEGER DEFAULT 1,
       pay REAL,
-      salary REAL
+      salary REAL,
+      hourly_rate REAL DEFAULT 20.0,
+      pto_accrual_rate REAL DEFAULT 0.0385,
+      streak_count INTEGER DEFAULT 0,
+      streak_last_date TEXT
     )
     """,
     """
@@ -39,6 +43,7 @@ tables = [
       clock_in TEXT,
       clock_out TEXT,
       duration_minutes INTEGER,
+      break_minutes INTEGER DEFAULT 0,
       notes TEXT
     )
     """,

--- a/backend/routes/clock_sessions.py
+++ b/backend/routes/clock_sessions.py
@@ -50,6 +50,8 @@ def _compute_session_duration(clock_in_str: str) -> int:
 
 @bp.route("/api/clock-sessions/<int:session_id>", methods=["PUT"])
 def clock_out(session_id):
+    data = request.get_json() or {}
+    unpaid_break_minutes = int(data.get("break_minutes", 0) or 0)
     now = datetime.utcnow().isoformat()
     with get_db() as db:
         row = db.execute("SELECT * FROM clock_sessions WHERE id = ?", (session_id,)).fetchone()
@@ -57,10 +59,11 @@ def clock_out(session_id):
             return jsonify({"error": "not found"}), 404
         if row["clock_out"]:
             return jsonify({"error": "already clocked out"}), 400
-        duration = _compute_session_duration(row["clock_in"])
+        total_minutes = _compute_session_duration(row["clock_in"])
+        net_minutes = max(0, total_minutes - unpaid_break_minutes)
         db.execute(
-            "UPDATE clock_sessions SET clock_out = ?, duration_minutes = ? WHERE id = ?",
-            (now, duration, session_id),
+            "UPDATE clock_sessions SET clock_out = ?, duration_minutes = ?, break_minutes = ? WHERE id = ?",
+            (now, net_minutes, unpaid_break_minutes, session_id),
         )
         db.commit()
         row = db.execute("SELECT * FROM clock_sessions WHERE id = ?", (session_id,)).fetchone()

--- a/backend/routes/users.py
+++ b/backend/routes/users.py
@@ -6,12 +6,13 @@ from db import get_db
 bp = Blueprint("users", __name__)
 
 
+_USER_COLS = "id, first_name, last_name, email, job_role, manager_name, is_fulltime, pay, salary, hourly_rate, pto_accrual_rate, streak_count, streak_last_date"
+
+
 @bp.route("/api/users", methods=["GET"])
 def list_users():
     with get_db() as db:
-        rows = db.execute(
-            "SELECT id, first_name, last_name, email, job_role, manager_name, is_fulltime, pay, salary FROM users ORDER BY id"
-        ).fetchall()
+        rows = db.execute(f"SELECT {_USER_COLS} FROM users ORDER BY id").fetchall()
     return jsonify([dict(r) for r in rows])
 
 
@@ -30,9 +31,9 @@ def create_user():
     with get_db() as db:
         try:
             row = db.execute(
-                """INSERT INTO users (first_name, last_name, email, password_hash, is_fulltime)
+                f"""INSERT INTO users (first_name, last_name, email, password_hash, is_fulltime)
                    VALUES (?, ?, ?, ?, 1)
-                   RETURNING id, first_name, last_name, email, job_role, manager_name, is_fulltime, pay, salary""",
+                   RETURNING {_USER_COLS}""",
                 (first_name, last_name, email, pw_hash),
             ).fetchone()
             db.commit()
@@ -45,7 +46,7 @@ def create_user():
 def get_user(uid):
     with get_db() as db:
         row = db.execute(
-            "SELECT id, first_name, last_name, email, job_role, manager_name, is_fulltime, pay, salary FROM users WHERE id = ?",
+            f"SELECT {_USER_COLS} FROM users WHERE id = ?",
             (uid,),
         ).fetchone()
     if not row:
@@ -56,7 +57,7 @@ def get_user(uid):
 @bp.route("/api/users/<int:uid>", methods=["PUT"])
 def update_user(uid):
     data = request.get_json() or {}
-    allowed = {"job_role", "manager_name", "is_fulltime", "pay", "salary"}
+    allowed = {"job_role", "manager_name", "is_fulltime", "pay", "salary", "hourly_rate", "pto_accrual_rate", "streak_count", "streak_last_date"}
     fields = {k: v for k, v in data.items() if k in allowed}
     if not fields:
         return jsonify({"error": "no updatable fields provided"}), 400
@@ -66,7 +67,7 @@ def update_user(uid):
         db.execute(f"UPDATE users SET {set_clause} WHERE id = ?", values)
         db.commit()
         row = db.execute(
-            "SELECT id, first_name, last_name, email, job_role, manager_name, is_fulltime, pay, salary FROM users WHERE id = ?",
+            f"SELECT {_USER_COLS} FROM users WHERE id = ?",
             (uid,),
         ).fetchone()
     if not row:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1330,6 +1330,8 @@ export default function App() {
   // Main app
   const [activeView, setActiveView] = useState<View>('clock')
   const [clockHourlyRate, setClockHourlyRate] = useState<number>(() => {
+    // Prefer DB value, fall back to localStorage, then derive from salary/pay
+    if (user?.hourly_rate != null) return Number(user.hourly_rate)
     const saved = localStorage.getItem('swiftshift-hourly-rate')
     if (saved) return parseFloat(saved)
     const salary = Number(user?.salary) || 0
@@ -1609,12 +1611,14 @@ export default function App() {
   // Tracks which reminder thresholds have already fired this clock session (reset on clock-in)
   const breakReminderFiredRef = useRef<Set<string>>(new Set())
 
-  // Daily streak counter (gamified punctuality)
+  // Daily streak counter (gamified punctuality) — prefer DB values, fall back to localStorage
   const [streak, setStreak] = useState<number>(() => {
+    if (user?.streak_count != null) return Number(user.streak_count)
     const saved = localStorage.getItem('streak')
     return saved ? parseInt(saved, 10) : 0
   })
   const [lastStreakDate, setLastStreakDate] = useState<string>(() => {
+    if (user?.streak_last_date) return user.streak_last_date
     return localStorage.getItem('lastStreakDate') || ''
   })
 
@@ -1898,6 +1902,14 @@ export default function App() {
         setLastStreakDate(todayStr)
         localStorage.setItem('streak', String(newStreak))
         localStorage.setItem('lastStreakDate', todayStr)
+        // Persist streak to DB
+        if (user?.id) {
+          fetch(`${API_BASE}/api/users/${user.id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ streak_count: newStreak, streak_last_date: todayStr }),
+          }).catch(() => {})
+        }
 
         // Streak milestone celebrations
         if ([5, 10, 20, 30, 50].includes(newStreak)) {
@@ -2039,11 +2051,16 @@ export default function App() {
       setLootDurationMin(Math.round(session / 60000))
       setShowLootDrop(true)
 
-      // Persist clock-out to DB
+      // Persist clock-out to DB (send unpaid break minutes so backend deducts them)
       const sid = activeSessionId
       setActiveSessionId(null)
+      const unpaidBreakMin = Math.round(unpaidAccum / 60000)
       if (sid && user?.id) {
-        fetch(`${API_BASE}/api/clock-sessions/${sid}`, { method: 'PUT' }).catch(() => {})
+        fetch(`${API_BASE}/api/clock-sessions/${sid}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ break_minutes: unpaidBreakMin }),
+        }).catch(() => {})
         // Accrue PTO to DB
         fetch(`${API_BASE}/api/pto/balance/accrue`, {
           method: 'POST',
@@ -2714,7 +2731,16 @@ export default function App() {
               theme={theme}
               user={user}
               highlightRate={highlightRate}
-              onRateChange={(rate) => setClockHourlyRate(rate)}
+              onRateChange={(rate) => {
+                setClockHourlyRate(rate)
+                if (user?.id) {
+                  fetch(`${API_BASE}/api/users/${user.id}`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ hourly_rate: rate }),
+                  }).catch(() => {})
+                }
+              }}
             />
           )}
           {activeView === 'admin' && (


### PR DESCRIPTION
Implements remaining gaps from issue #84 on a conflict-free branch:

- Clock-out sends unpaid `break_minutes` to backend; `duration_minutes` is net (total - unpaid breaks)
- `break_minutes` column added to `clock_sessions` table
- `hourly_rate`, `pto_accrual_rate`, `streak_count`, `streak_last_date` added to `users` table
- Auto-migration in `auth.py` so existing DBs upgrade on next start
- `signin` response includes new fields
- Frontend reads hourly rate and streak from DB on login; writes back on change

Closes #84

Generated with [Claude Code](https://claude.ai/code)