### PR TITLE
fix: use relative venv path so build works on both Railway and Render

### DIFF
--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -1,12 +1,23 @@
 """One-time script to create all database tables. Run once after first deploy."""
 import psycopg2
 import os
+import sys
 
 DATABASE_URL = os.environ.get("DATABASE_URL")
 if not DATABASE_URL:
-    raise SystemExit("DATABASE_URL not set")
+    raise SystemExit("DATABASE_URL not set — add it in your Railway/Render environment variables.")
 
-conn = psycopg2.connect(DATABASE_URL)
+try:
+    conn = psycopg2.connect(DATABASE_URL)
+except psycopg2.OperationalError as e:
+    print(f"ERROR: Cannot connect to database: {e}", file=sys.stderr)
+    print(
+        "Check that DATABASE_URL is set to your actual PostgreSQL connection string.\n"
+        "On Railway: link a Postgres service and Railway will inject DATABASE_URL automatically.\n"
+        "On Render: add DATABASE_URL in Environment → Environment Variables.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 conn.autocommit = True
 cur = conn.cursor()
 

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ npm run build
 cd ..
 
 echo "Installing backend dependencies..."
-python3 -m venv /app/venv
-/app/venv/bin/pip install --no-cache-dir -r backend/requirements.txt
+python3 -m venv venv
+venv/bin/pip install --no-cache-dir -r backend/requirements.txt
 
 echo "Done!"

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 export PATH=/mise/shims:$PATH
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd backend
-/app/venv/bin/python3 init_db.py
-exec /app/venv/bin/gunicorn app:app --workers 4 --bind 0.0.0.0:$PORT
+"${SCRIPT_DIR}/venv/bin/python3" init_db.py
+exec "${SCRIPT_DIR}/venv/bin/gunicorn" app:app --workers 4 --bind 0.0.0.0:$PORT


### PR DESCRIPTION
Fixes two deployment failures reported in issue #105.

- `build.sh`: replaced hardcoded `/app/venv` with `./venv` so Render no longer errors with "Read-only file system: /app" during build
- `start.sh`: derive SCRIPT_DIR so the venv path is always correct regardless of caller working directory
- `init_db.py`: wrap psycopg2.connect() in try/except and print actionable instructions when DATABASE_URL points to a non-existent host

Generated with [Claude Code](https://claude.ai/code)