### PR TITLE
fix: pin numpy<2.0 to fix chromadb Railway deploy

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,6 +4,7 @@ flask-limiter>=3.0.0
 psycopg2-binary>=2.9.0
 openai>=1.0.0
 chromadb>=0.4.0,<0.5.0
+numpy<2.0
 pypdf>=4.0.0
 python-docx>=1.1.0
 requests


### PR DESCRIPTION
Fixes #108

Adds `numpy<2.0` to `backend/requirements.txt` to prevent the `AttributeError: np.float_ was removed in NumPy 2.0` crash caused by chromadb 0.4.x being incompatible with NumPy 2.x.

Generated with [Claude Code](https://claude.ai/code)