### PR TITLE
fix: AUTOINCREMENT → SERIAL for PostgreSQL compatibility

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -150,7 +150,7 @@ def _ensure_password_reset_tokens_table():
         db.execute(
             """
             CREATE TABLE IF NOT EXISTS password_reset_tokens (
-              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              id SERIAL PRIMARY KEY,
               user_id INTEGER NOT NULL,
               token TEXT UNIQUE NOT NULL,
               expires_at INTEGER NOT NULL,


### PR DESCRIPTION
Fixes Railway deploy crash caused by SQLite syntax in the `password_reset_tokens` table creation. PostgreSQL does not support `AUTOINCREMENT` — changed to `SERIAL PRIMARY KEY` to match all other tables in the file.

Closes #111

Generated with [Claude Code](https://claude.ai/code)