### PR TITLE
feat: smooth tour animations with sidebar pointer and fintech icons

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -292,16 +292,16 @@ const XP_LEVELS = [
 ]
 
 const ACHIEVEMENTS = [
-  { id: 'first_timer', icon: '🎯', name: 'First Timer', desc: 'Submit your first timesheet', check: (s: GamificationState) => s.submits >= 1 },
-  { id: 'overtime_warrior', icon: '⚡', name: 'Overtime Warrior', desc: 'Log more than 80h in a period', check: (s: GamificationState) => s.maxPeriodHours >= 80 },
-  { id: 'speed_logger', icon: '💬', name: 'Speed Logger', desc: 'Use NLP 10 times', check: (s: GamificationState) => s.nlpUses >= 10 },
-  { id: 'perfect_period', icon: '💎', name: 'Perfect Period', desc: 'Log hours every day in a period', check: (s: GamificationState) => s.perfectPeriods >= 1 },
-  { id: 'hat_trick', icon: '🔥', name: 'Hat Trick', desc: 'Submit 3 periods in a row', check: (s: GamificationState) => s.streak >= 3 },
-  { id: 'marathon', icon: '🏃', name: 'Marathon', desc: 'Earn 500 XP total', check: (s: GamificationState) => s.totalXP >= 500 },
-  { id: 'consistency', icon: '⭐', name: 'Consistency', desc: 'Submit 5 timesheets', check: (s: GamificationState) => s.submits >= 5 },
-  { id: 'century', icon: '💯', name: 'Century Club', desc: 'Earn 1000 XP total', check: (s: GamificationState) => s.totalXP >= 1000 },
-  { id: 'level5', icon: '🏅', name: 'Level 5', desc: 'Reach level 5', check: (s: GamificationState) => s.totalXP >= 700 },
-  { id: 'legend', icon: '👑', name: 'Legend', desc: 'Reach max level', check: (s: GamificationState) => s.totalXP >= 3200 },
+  { id: 'first_timer', icon: '◎', name: 'First Timer', desc: 'Submit your first timesheet', check: (s: GamificationState) => s.submits >= 1 },
+  { id: 'overtime_warrior', icon: '↑', name: 'Overtime Warrior', desc: 'Log more than 80h in a period', check: (s: GamificationState) => s.maxPeriodHours >= 80 },
+  { id: 'speed_logger', icon: '»', name: 'Speed Logger', desc: 'Use NLP 10 times', check: (s: GamificationState) => s.nlpUses >= 10 },
+  { id: 'perfect_period', icon: '◆', name: 'Perfect Period', desc: 'Log hours every day in a period', check: (s: GamificationState) => s.perfectPeriods >= 1 },
+  { id: 'hat_trick', icon: '▲', name: 'Hat Trick', desc: 'Submit 3 periods in a row', check: (s: GamificationState) => s.streak >= 3 },
+  { id: 'marathon', icon: '→', name: 'Marathon', desc: 'Earn 500 XP total', check: (s: GamificationState) => s.totalXP >= 500 },
+  { id: 'consistency', icon: '★', name: 'Consistency', desc: 'Submit 5 timesheets', check: (s: GamificationState) => s.submits >= 5 },
+  { id: 'century', icon: '◉', name: 'Century Club', desc: 'Earn 1000 XP total', check: (s: GamificationState) => s.totalXP >= 1000 },
+  { id: 'level5', icon: '✦', name: 'Level 5', desc: 'Reach level 5', check: (s: GamificationState) => s.totalXP >= 700 },
+  { id: 'legend', icon: '⬡', name: 'Legend', desc: 'Reach max level', check: (s: GamificationState) => s.totalXP >= 3200 },
 ]
 
 interface GamificationState {
@@ -610,8 +610,14 @@ function TimesheetView({ user }: { user: any }) {
           </div>
         </div>
         <div className="flex items-center gap-3 text-xs text-zinc-400 flex-shrink-0">
-          <span>🔥 {gState.streak} streak</span>
-          <span>📋 {gState.submits} submitted</span>
+          <span className="flex items-center gap-1">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M8.5 14.5A2.5 2.5 0 0011 17h2a2.5 2.5 0 002.5-2.5c0-1.5-.5-2-1-3a6 6 0 001-6.5A6 6 0 018 7c-1 2-1.5 3.5-.5 6 .5 1.5 1 2 1 2z"/><path d="M12 22c2.5 0 4-1.5 4-4h-8c0 2.5 1.5 4 4 4z"/></svg>
+            {gState.streak} streak
+          </span>
+          <span className="flex items-center gap-1">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+            {gState.submits} submitted
+          </span>
         </div>
       </div>
 
@@ -830,7 +836,7 @@ function TimesheetView({ user }: { user: any }) {
             disabled={!certified || isSubmitted}
             className="glass-btn-green px-5 py-2.5 rounded-xl font-semibold text-sm disabled:opacity-40 disabled:cursor-not-allowed"
           >
-            Submit timesheet 🎉
+            Submit timesheet
           </button>
         </div>
 
@@ -1003,13 +1009,17 @@ function ResetPasswordPage() {
         </div>
         {!token ? (
           <div className="text-center py-4 space-y-3">
-            <div className="text-4xl">⚠️</div>
+            <div className="flex justify-center mb-1">
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="#ef4444" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+            </div>
             <p className="text-sm text-zinc-400">Invalid reset link. Please request a new one.</p>
             <a href="login" className="inline-block text-sm underline underline-offset-4 text-zinc-400 hover:text-white transition-colors">Back to sign in</a>
           </div>
         ) : success ? (
           <div className="text-center py-4 space-y-3">
-            <div className="text-4xl">✅</div>
+            <div className="flex justify-center mb-1">
+              <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="var(--accent-color)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+            </div>
             <p className="text-sm text-zinc-400">Password updated successfully!</p>
             <a href="login" className="inline-block text-sm underline underline-offset-4 text-zinc-400 hover:text-white transition-colors">Sign in</a>
           </div>
@@ -2430,7 +2440,11 @@ export default function App() {
         <div className="ta-navbar-user">
           {/* Daily streak counter */}
           <div className="flex items-center gap-1.5 px-3 py-1 text-sm text-white/60 border border-white/10 rounded-full">
-            <span style={{ color: 'var(--accent-color)' }}>{streak > 0 ? '🔥' : '○'}</span>
+            <span style={{ color: 'var(--accent-color)' }}>
+              {streak > 0
+                ? <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{display:'inline',verticalAlign:'middle'}}><path d="M8.5 14.5A2.5 2.5 0 0011 17h2a2.5 2.5 0 002.5-2.5c0-1.5-.5-2-1-3a6 6 0 001-6.5A6 6 0 018 7c-1 2-1.5 3.5-.5 6 .5 1.5 1 2 1 2z"/><path d="M12 22c2.5 0 4-1.5 4-4h-8c0 2.5 1.5 4 4 4z"/></svg>
+                : <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{display:'inline',verticalAlign:'middle'}}><circle cx="12" cy="12" r="8"/></svg>}
+            </span>
             <span className="font-semibold" style={{ color: 'var(--accent-color)' }}>{streak}</span>
             <span className="text-white/40 ta-streak-label">day streak</span>
           </div>
@@ -2486,6 +2500,7 @@ export default function App() {
       <aside className={`ta-sidebar ${mobileMenuOpen ? 'mobile-open' : ''}`}>
         <nav className="ta-nav">
           <button
+            id="nav-clock"
             className={`ta-nav-btn ${activeView === 'clock' ? 'active' : ''}`}
             onClick={() => navTo('clock')}
           >
@@ -2495,6 +2510,7 @@ export default function App() {
             Time Clock
           </button>
           <button
+            id="nav-timesheet"
             className={`ta-nav-btn ${activeView === 'timesheet' ? 'active' : ''}`}
             onClick={() => navTo('timesheet')}
           >
@@ -2504,6 +2520,7 @@ export default function App() {
             Timesheet
           </button>
           <button
+            id="nav-rewards"
             className={`ta-nav-btn ${activeView === 'rewards' ? 'active' : ''}`}
             onClick={() => navTo('rewards')}
           >
@@ -2540,6 +2557,7 @@ export default function App() {
             Files
           </button>
           <button
+            id="nav-groktax"
             className={`ta-nav-btn mb-2 ${activeView === 'groktax' ? 'active' : ''}`}
             onClick={() => navTo('groktax')}
           >
@@ -2550,6 +2568,7 @@ export default function App() {
           </button>
           <div className="ta-nav-section">Job Applications</div>
           <button
+            id="nav-applications"
             className={`ta-nav-btn mb-2 ${activeView === 'applications' ? 'active' : ''}`}
             onClick={() => navTo('applications')}
           >
@@ -2578,6 +2597,7 @@ export default function App() {
             Schedule Management
           </button>
           <button
+            id="nav-payroll"
             className={`ta-nav-btn ${activeView === 'payroll' ? 'active' : ''}`}
             onClick={() => navTo('payroll')}
           >
@@ -2625,6 +2645,7 @@ export default function App() {
         </nav>
         <div className="mt-auto pt-4">
           <button
+            id="nav-grokky"
             className={`ta-nav-btn ${activeView === 'grokky' ? 'active' : ''}`}
             onClick={() => navTo('grokky')}
             style={{ color: 'var(--accent-color)', textShadow: '0 0 8px var(--accent-color)' }}

--- a/frontend/src/components/BreakReminderModal.tsx
+++ b/frontend/src/components/BreakReminderModal.tsx
@@ -53,10 +53,13 @@ export function BreakReminderModal({
             {/* Icon + state badge */}
             <div className="flex items-center gap-3 mb-5">
               <div
-                className="w-12 h-12 rounded-2xl flex items-center justify-center text-2xl flex-shrink-0"
-                style={{ background: `${urgencyColor}22`, border: `1px solid ${urgencyColor}44` }}
+                className="w-12 h-12 rounded-2xl flex items-center justify-center flex-shrink-0"
+                style={{ background: `${urgencyColor}22`, border: `1px solid ${urgencyColor}44`, color: urgencyColor }}
               >
-                🍽️
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M18 8h1a4 4 0 010 8h-1"/><path d="M2 8h16v9a4 4 0 01-4 4H6a4 4 0 01-4-4V8z"/>
+                  <line x1="6" y1="1" x2="6" y2="4"/><line x1="10" y1="1" x2="10" y2="4"/><line x1="14" y1="1" x2="14" y2="4"/>
+                </svg>
               </div>
               <div>
                 <div className="text-xs uppercase tracking-[2px] text-zinc-500">

--- a/frontend/src/components/ClockWidget.tsx
+++ b/frontend/src/components/ClockWidget.tsx
@@ -32,7 +32,9 @@ export function ClockWidget({ onClockChange, onClockOut }: ClockWidgetProps) {
           whileHover={{ scale: 1.01 }}
           whileTap={{ scale: 0.985 }}
         >
-          <div className="text-6xl">⏱</div>
+          <svg width="52" height="52" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: 0.85 }}>
+            <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
+          </svg>
           <div>CLOCK IN</div>
           <div className="text-sm font-normal opacity-60">Tap once. That's it.</div>
         </motion.button>

--- a/frontend/src/components/FeaturePreview.tsx
+++ b/frontend/src/components/FeaturePreview.tsx
@@ -1,15 +1,73 @@
 import { motion } from 'framer-motion'
 
+const FeatureIcons: Record<string, React.ReactNode> = {
+  clock: (
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
+    </svg>
+  ),
+  document: (
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/>
+      <polyline points="14 2 14 8 20 8"/>
+      <line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/>
+    </svg>
+  ),
+  trophy: (
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/>
+    </svg>
+  ),
+  card: (
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="2" y="5" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/>
+    </svg>
+  ),
+  dollar: (
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <line x1="12" y1="1" x2="12" y2="23"/>
+      <path d="M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6"/>
+    </svg>
+  ),
+  bot: (
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 2a2 2 0 012 2c0 .74-.4 1.39-1 1.73V7h1a7 7 0 017 7h1a1 1 0 011 1v3a1 1 0 01-1 1h-1a7 7 0 01-7 7H9a7 7 0 01-7-7H1a1 1 0 01-1-1v-3a1 1 0 011-1h1a7 7 0 017-7h1V5.73c-.6-.34-1-.99-1-1.73a2 2 0 012-2z"/>
+      <circle cx="9" cy="14" r="1" fill="currentColor"/><circle cx="15" cy="14" r="1" fill="currentColor"/>
+    </svg>
+  ),
+  lightning: (
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
+    </svg>
+  ),
+  shield: (
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+    </svg>
+  ),
+  orgchart: (
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="8" y="2" width="8" height="4" rx="1"/>
+      <rect x="2" y="14" width="8" height="4" rx="1"/>
+      <rect x="14" y="14" width="8" height="4" rx="1"/>
+      <line x1="12" y1="6" x2="12" y2="11"/>
+      <line x1="6" y1="14" x2="6" y2="11"/>
+      <line x1="18" y1="14" x2="18" y2="11"/>
+      <line x1="6" y1="11" x2="18" y2="11"/>
+    </svg>
+  ),
+}
+
 const FEATURES = [
-  { icon: '⏱', title: 'Time Clock', desc: 'Clock in/out with one click. Real-time earnings display and break tracking.' },
-  { icon: '📋', title: 'Timesheet', desc: 'View, edit, and submit all your time entries. Track hours by project and task.' },
-  { icon: '🏆', title: 'Rewards', desc: 'Gamified daily streaks and real-time earnings Odometer for every second worked.' },
-  { icon: '💳', title: 'Payroll & Reports', desc: 'Full pay details, analytics dashboards, and exportable reports.' },
-  { icon: '💰', title: 'AI Tax Filing', desc: 'Upload your W-2 or 1099 and Swifty AI fills out your 1040 instantly.' },
-  { icon: '🤖', title: 'AI Assistant', desc: 'Chat with Swifty for instant HR answers, leave policy info, and more.' },
-  { icon: '⚡', title: 'InstaApply', desc: 'Upload your resume once — get matched to jobs and apply in seconds.' },
-  { icon: '🛡', title: 'Insurance & Benefits', desc: 'Browse and manage your health, dental, and vision benefits.' },
-  { icon: '📊', title: 'Org Chart', desc: 'Visualize your entire company structure at a glance.' },
+  { iconKey: 'clock', title: 'Time Clock', desc: 'Clock in/out with one click. Real-time earnings display and break tracking.' },
+  { iconKey: 'document', title: 'Timesheet', desc: 'View, edit, and submit all your time entries. Track hours by project and task.' },
+  { iconKey: 'trophy', title: 'Rewards', desc: 'Gamified daily streaks and real-time earnings Odometer for every second worked.' },
+  { iconKey: 'card', title: 'Payroll & Reports', desc: 'Full pay details, analytics dashboards, and exportable reports.' },
+  { iconKey: 'dollar', title: 'AI Tax Filing', desc: 'Upload your W-2 or 1099 and Swifty AI fills out your 1040 instantly.' },
+  { iconKey: 'bot', title: 'AI Assistant', desc: 'Chat with Swifty for instant HR answers, leave policy info, and more.' },
+  { iconKey: 'lightning', title: 'InstaApply', desc: 'Upload your resume once — get matched to jobs and apply in seconds.' },
+  { iconKey: 'shield', title: 'Insurance & Benefits', desc: 'Browse and manage your health, dental, and vision benefits.' },
+  { iconKey: 'orgchart', title: 'Org Chart', desc: 'Visualize your entire company structure at a glance.' },
 ]
 
 interface FeaturePreviewProps {
@@ -18,6 +76,7 @@ interface FeaturePreviewProps {
 }
 
 export function FeaturePreview({ onClose, accentHex = '#D7FE51' }: FeaturePreviewProps) {
+  const isDark = ['#D7FE51', '#E5E7EB', '#51FEFE', '#FE51D7'].includes(accentHex)
   return (
     <div
       className="fixed inset-0 z-[300] flex items-center justify-center bg-black/80 backdrop-blur-sm p-4"
@@ -58,7 +117,12 @@ export function FeaturePreview({ onClose, accentHex = '#D7FE51' }: FeaturePrevie
                 className="rounded-2xl border border-white/8 p-4 hover:border-white/15 transition-colors"
                 style={{ background: 'rgba(255,255,255,0.025)' }}
               >
-                <div className="text-2xl mb-2 leading-none">{f.icon}</div>
+                <div
+                  className="w-8 h-8 rounded-xl flex items-center justify-center mb-3"
+                  style={{ background: `${accentHex}15`, color: accentHex, border: `1px solid ${accentHex}25` }}
+                >
+                  {FeatureIcons[f.iconKey]}
+                </div>
                 <div className="font-semibold text-sm mb-1 text-white">{f.title}</div>
                 <div className="text-xs text-zinc-500 leading-relaxed">{f.desc}</div>
               </div>
@@ -71,7 +135,7 @@ export function FeaturePreview({ onClose, accentHex = '#D7FE51' }: FeaturePrevie
           <button
             onClick={onClose}
             className="w-full py-2.5 rounded-xl text-sm font-semibold transition-all hover:opacity-90 active:scale-[0.98]"
-            style={{ background: accentHex, color: accentHex === '#D7FE51' || accentHex === '#E5E7EB' || accentHex === '#51FEFE' || accentHex === '#FE51D7' ? '#000' : '#fff' }}
+            style={{ background: accentHex, color: isDark ? '#000' : '#fff' }}
           >
             Got it — let's go
           </button>

--- a/frontend/src/components/Rewards.tsx
+++ b/frontend/src/components/Rewards.tsx
@@ -2,6 +2,41 @@ import { useEffect, useState, useRef, useCallback } from 'react'
 import confetti from 'canvas-confetti'
 import { motion } from 'framer-motion'
 
+const AchievementIcons: Record<string, React.ReactNode> = {
+  lightning: (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
+    </svg>
+  ),
+  century: (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/>
+    </svg>
+  ),
+  flame: (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M8.5 14.5A2.5 2.5 0 0011 17h2a2.5 2.5 0 002.5-2.5c0-1.5-.5-2-1-3a6 6 0 011-6.5A6 6 0 018 7c-1 2-1.5 3.5-.5 6 .5 1.5 1 2 1 2z"/>
+      <path d="M12 22c2.5 0 4-1.5 4-4h-8c0 2.5 1.5 4 4 4z"/>
+    </svg>
+  ),
+  target: (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/>
+    </svg>
+  ),
+  diamond: (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <polygon points="12 2 22 8.5 22 15.5 12 22 2 15.5 2 8.5 12 2"/>
+      <line x1="12" y1="2" x2="12" y2="22"/><line x1="2" y1="8.5" x2="22" y2="8.5"/>
+    </svg>
+  ),
+  umbrella: (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M23 12a11.05 11.05 0 00-22 0zm-5 7a3 3 0 01-6 0v-7"/>
+    </svg>
+  ),
+}
+
 interface RewardsProps {
   totalHours: number
   elapsedSeconds: number
@@ -64,12 +99,12 @@ export function Rewards({ totalHours, elapsedSeconds, isClockedIn, theme = 'gree
   const xpProgress = Math.min(100, ((totalXP - xpForCurrentLevel) / 500) * 100)
 
   const achievements = [
-    { id: 'first_shift', label: 'First Shift', icon: '⚡', desc: 'Clock in for the first time', unlocked: totalHours > 0 || isClockedIn },
-    { id: 'century', label: 'Century Club', icon: '💯', desc: 'Earn $100 in a day', unlocked: earnedToday >= 100 },
-    { id: 'overtime', label: 'Overtime Warrior', icon: '🔥', desc: 'Work over 9 hours', unlocked: totalHours > 9 },
-    { id: 'streak_3', label: 'On a Roll', icon: '🎯', desc: 'Work 3 days in a row', unlocked: streak >= 3 },
-    { id: 'high_earner', label: 'High Earner', icon: '💎', desc: 'Earn $500 in a week', unlocked: totalEarnings >= 500 },
-    { id: 'pto_master', label: 'PTO Hoarder', icon: '🏖️', desc: 'Accrue 1 hour of PTO', unlocked: accruedPTO >= 1 },
+    { id: 'first_shift', label: 'First Shift', iconKey: 'lightning', desc: 'Clock in for the first time', unlocked: totalHours > 0 || isClockedIn },
+    { id: 'century', label: 'Century Club', iconKey: 'century', desc: 'Earn $100 in a day', unlocked: earnedToday >= 100 },
+    { id: 'overtime', label: 'Overtime Warrior', iconKey: 'flame', desc: 'Work over 9 hours', unlocked: totalHours > 9 },
+    { id: 'streak_3', label: 'On a Roll', iconKey: 'target', desc: 'Work 3 days in a row', unlocked: streak >= 3 },
+    { id: 'high_earner', label: 'High Earner', iconKey: 'diamond', desc: 'Earn $500 in a week', unlocked: totalEarnings >= 500 },
+    { id: 'pto_master', label: 'PTO Hoarder', iconKey: 'umbrella', desc: 'Accrue 1 hour of PTO', unlocked: accruedPTO >= 1 },
   ]
 
   // Paycheck helpers
@@ -445,7 +480,12 @@ export function Rewards({ totalHours, elapsedSeconds, isClockedIn, theme = 'gree
         {/* Work Streak */}
         <div className="glass rounded-3xl p-6 text-center flex flex-col items-center justify-center">
           <div className="text-lg font-semibold neon-green uppercase tracking-[2px] mb-2">Work Streak</div>
-          <div className="text-4xl mb-1 select-none">🔥</div>
+          <div className="mb-1 select-none flex items-center justify-center" style={{ color: 'var(--accent-color)' }}>
+            <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M8.5 14.5A2.5 2.5 0 0011 17h2a2.5 2.5 0 002.5-2.5c0-1.5-.5-2-1-3a6 6 0 001-6.5A6 6 0 018 7c-1 2-1.5 3.5-.5 6 .5 1.5 1 2 1 2z"/>
+              <path d="M12 22c2.5 0 4-1.5 4-4h-8c0 2.5 1.5 4 4 4z"/>
+            </svg>
+          </div>
           <div className="text-4xl font-bold neon-green tabular-nums">{streak}</div>
           <div className="text-xs text-zinc-500 mt-1.5">
             {streak === 0
@@ -525,7 +565,9 @@ export function Rewards({ totalHours, elapsedSeconds, isClockedIn, theme = 'gree
                   : {}
               }
             >
-              <div className="text-2xl mb-2 select-none">{ach.icon}</div>
+              <div className="w-8 h-8 rounded-xl flex items-center justify-center mb-2 select-none" style={{ background: `${accentColor}18`, color: ach.unlocked ? accentColor : 'rgba(255,255,255,0.3)', border: `1px solid ${accentColor}25` }}>
+                {AchievementIcons[ach.iconKey]}
+              </div>
               <div className="text-sm font-semibold neon-green leading-tight">{ach.label}</div>
               <div className="text-xs text-zinc-500 mt-1 leading-snug">{ach.desc}</div>
               {ach.unlocked && (

--- a/frontend/src/components/Tour.tsx
+++ b/frontend/src/components/Tour.tsx
@@ -1,59 +1,160 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 
+// Fintech-style SVG icon components
+const ClockIcon = () => (
+  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
+  </svg>
+)
+
+const DocumentIcon = () => (
+  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/>
+    <polyline points="14 2 14 8 20 8"/>
+    <line x1="16" y1="13" x2="8" y2="13"/>
+    <line x1="16" y1="17" x2="8" y2="17"/>
+  </svg>
+)
+
+const TrophyIcon = () => (
+  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/>
+  </svg>
+)
+
+const CreditCardIcon = () => (
+  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="2" y="5" width="20" height="14" rx="2"/>
+    <line x1="2" y1="10" x2="22" y2="10"/>
+    <line x1="6" y1="15" x2="10" y2="15"/>
+  </svg>
+)
+
+const DollarIcon = () => (
+  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <line x1="12" y1="1" x2="12" y2="23"/>
+    <path d="M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6"/>
+  </svg>
+)
+
+const BotIcon = () => (
+  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 2a2 2 0 012 2c0 .74-.4 1.39-1 1.73V7h1a7 7 0 017 7h1a1 1 0 011 1v3a1 1 0 01-1 1h-1a7 7 0 01-7 7H9a7 7 0 01-7-7H1a1 1 0 01-1-1v-3a1 1 0 011-1h1a7 7 0 017-7h1V5.73c-.6-.34-1-.99-1-1.73a2 2 0 012-2z"/>
+    <circle cx="9" cy="14" r="1" fill="currentColor"/><circle cx="15" cy="14" r="1" fill="currentColor"/>
+  </svg>
+)
+
+const LightningIcon = () => (
+  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
+  </svg>
+)
+
+const CheckCircleIcon = () => (
+  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M22 11.08V12a10 10 0 11-5.93-9.14"/>
+    <polyline points="22 4 12 14.01 9 11.01"/>
+  </svg>
+)
+
+const SparkleIcon = () => (
+  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 2l2.4 7.4H22l-6.2 4.5 2.4 7.1-6.2-4.5-6.2 4.5 2.4-7.1L2 9.4h7.6L12 2z"/>
+  </svg>
+)
+
 interface TourStep {
-  icon: string
+  icon: React.ReactNode
   title: string
   desc: string
+  targetId: string | null
 }
 
 const TOUR_STEPS: TourStep[] = [
   {
-    icon: '👋',
+    icon: <SparkleIcon />,
     title: 'Welcome to SwiftShift!',
     desc: "You're in. Let's take a 60-second tour of the key features so you can hit the ground running.",
+    targetId: null,
   },
   {
-    icon: '⏱',
+    icon: <ClockIcon />,
     title: 'Time Clock',
     desc: 'Clock in and out with one click. Your earnings update in real time — every second counts. Track breaks too.',
+    targetId: 'nav-clock',
   },
   {
-    icon: '📋',
+    icon: <DocumentIcon />,
     title: 'Timesheet',
     desc: 'All your time entries in one place. Add, edit, and submit your weekly timesheet with ease.',
+    targetId: 'nav-timesheet',
   },
   {
-    icon: '🏆',
+    icon: <TrophyIcon />,
     title: 'Rewards',
     desc: 'Stay consistent and earn streak rewards. Watch your real-time earnings climb on the Odometer.',
+    targetId: 'nav-rewards',
   },
   {
-    icon: '💳',
+    icon: <CreditCardIcon />,
     title: 'Payroll & Reports',
     desc: 'View pay details, export reports, and track your analytics — all in one dashboard.',
+    targetId: 'nav-payroll',
   },
   {
-    icon: '💰',
+    icon: <DollarIcon />,
     title: 'AI Tax Filing — Swifty',
     desc: 'Upload your W-2 or 1099 and Swifty fills out your Form 1040 instantly. No accountant needed.',
+    targetId: 'nav-groktax',
   },
   {
-    icon: '🤖',
+    icon: <BotIcon />,
     title: 'AI Assistant — Swifty',
     desc: 'Ask Swifty anything — leave policies, HR questions, company info. Instant, intelligent answers.',
+    targetId: 'nav-grokky',
   },
   {
-    icon: '⚡',
+    icon: <LightningIcon />,
     title: 'InstaApply',
     desc: 'Upload your resume once. SwiftShift matches you to jobs and applies in seconds.',
+    targetId: 'nav-applications',
   },
   {
-    icon: '✅',
+    icon: <CheckCircleIcon />,
     title: "You're all set!",
     desc: "That covers the highlights. Start by clocking in — your first session is just one click away.",
+    targetId: null,
   },
 ]
+
+const BOX_WIDTH = 400
+const BOX_HEIGHT_EST = 390
+
+interface BoxPosition {
+  top: number
+  left: number
+  hasArrow: boolean
+  arrowTop: number
+}
+
+function computePosition(stepIndex: number): BoxPosition {
+  const step = TOUR_STEPS[stepIndex]
+  const centered: BoxPosition = {
+    top: Math.max(64, (window.innerHeight - BOX_HEIGHT_EST) / 2),
+    left: Math.max(0, (window.innerWidth - BOX_WIDTH) / 2),
+    hasArrow: false,
+    arrowTop: 0,
+  }
+  if (!step.targetId) return centered
+  const target = document.getElementById(step.targetId)
+  if (!target) return centered
+  const rect = target.getBoundingClientRect()
+  const left = 240 + 28
+  const targetMidY = rect.top + rect.height / 2
+  const top = Math.max(80, Math.min(window.innerHeight - BOX_HEIGHT_EST - 24, targetMidY - BOX_HEIGHT_EST / 2))
+  return { top, left, hasArrow: true, arrowTop: targetMidY - top }
+}
 
 interface TourProps {
   onClose: () => void
@@ -62,41 +163,92 @@ interface TourProps {
 
 export function Tour({ onClose, accentHex = '#D7FE51' }: TourProps) {
   const [step, setStep] = useState(0)
+  const [pos, setPos] = useState<BoxPosition>(() => computePosition(0))
+
   const current = TOUR_STEPS[step]
   const isLast = step === TOUR_STEPS.length - 1
-  const isDark = accentHex === '#D7FE51' || accentHex === '#E5E7EB' || accentHex === '#51FEFE' || accentHex === '#FE51D7'
+  const isDark = ['#D7FE51', '#E5E7EB', '#51FEFE', '#FE51D7'].includes(accentHex)
 
-  const next = () => {
-    if (isLast) onClose()
-    else setStep(s => s + 1)
-  }
+  useEffect(() => {
+    const newPos = computePosition(step)
+    setPos(newPos)
 
-  const prev = () => {
-    if (step > 0) setStep(s => s - 1)
-  }
+    // Apply highlight to target nav button
+    const target = current.targetId ? document.getElementById(current.targetId) : null
+    if (target) {
+      target.style.boxShadow = `0 0 0 2px ${accentHex}80, inset 3px 0 0 ${accentHex}`
+      target.style.background = `${accentHex}18`
+      target.style.color = '#fff'
+    }
+    return () => {
+      if (target) {
+        target.style.boxShadow = ''
+        target.style.background = ''
+        target.style.color = ''
+      }
+    }
+  }, [step, current.targetId, accentHex])
+
+  useEffect(() => {
+    return () => {
+      TOUR_STEPS.forEach(s => {
+        if (s.targetId) {
+          const el = document.getElementById(s.targetId)
+          if (el) { el.style.boxShadow = ''; el.style.background = ''; el.style.color = '' }
+        }
+      })
+    }
+  }, [])
+
+  const next = () => { if (isLast) onClose(); else setStep(s => s + 1) }
+  const prev = () => { if (step > 0) setStep(s => s - 1) }
 
   return (
     <div
-      className="fixed inset-0 z-[300] flex items-center justify-center bg-black/75 backdrop-blur-sm"
+      className="fixed inset-0 z-[300] bg-black/75 backdrop-blur-sm"
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
     >
-      <AnimatePresence mode="wait">
-        <motion.div
-          key={step}
-          initial={{ opacity: 0, y: 20, scale: 0.97 }}
-          animate={{ opacity: 1, y: 0, scale: 1 }}
-          exit={{ opacity: 0, y: -10, scale: 0.97 }}
-          transition={{ duration: 0.22, ease: 'easeOut' }}
-          className="glass w-full max-w-[420px] rounded-3xl p-8 border border-white/10 mx-4"
-          style={{ boxShadow: `0 0 80px -20px ${accentHex}35, 0 28px 72px -14px rgba(0,0,0,0.85)` }}
-        >
+      <motion.div
+        initial={{ top: pos.top, left: pos.left, opacity: 0, scale: 0.96 }}
+        animate={{ top: pos.top, left: pos.left, opacity: 1, scale: 1 }}
+        transition={{ type: 'spring', stiffness: 320, damping: 38 }}
+        className="absolute glass rounded-3xl border border-white/10"
+        style={{
+          width: BOX_WIDTH,
+          boxShadow: `0 0 80px -20px ${accentHex}35, 0 28px 72px -14px rgba(0,0,0,0.85)`,
+        }}
+      >
+        {/* Arrow pointing left toward sidebar */}
+        <AnimatePresence>
+          {pos.hasArrow && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1, top: pos.arrowTop }}
+              exit={{ opacity: 0 }}
+              transition={{ type: 'spring', stiffness: 320, damping: 38 }}
+              style={{
+                position: 'absolute',
+                left: -11,
+                width: 0,
+                height: 0,
+                borderTop: '11px solid transparent',
+                borderBottom: '11px solid transparent',
+                borderRight: `11px solid ${accentHex}`,
+                transform: 'translateY(-50%)',
+                filter: `drop-shadow(-2px 0 6px ${accentHex}50)`,
+              }}
+            />
+          )}
+        </AnimatePresence>
+
+        <div className="p-8">
           {/* Progress bar */}
-          <div className="h-1 rounded-full bg-white/10 mb-6 overflow-hidden">
+          <div className="h-0.5 rounded-full bg-white/10 mb-6 overflow-hidden">
             <motion.div
               className="h-full rounded-full"
               style={{ backgroundColor: accentHex }}
               animate={{ width: `${((step + 1) / TOUR_STEPS.length) * 100}%` }}
-              transition={{ duration: 0.35 }}
+              transition={{ duration: 0.4, ease: 'easeOut' }}
             />
           </div>
 
@@ -105,21 +257,41 @@ export function Tour({ onClose, accentHex = '#D7FE51' }: TourProps) {
             Step {step + 1} <span className="text-zinc-700">/ {TOUR_STEPS.length}</span>
           </div>
 
-          {/* Icon */}
-          <div className="text-5xl mb-4 leading-none">{current.icon}</div>
+          {/* Animated content */}
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.div
+              key={step}
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -6 }}
+              transition={{ duration: 0.16, ease: 'easeOut' }}
+            >
+              {/* Icon */}
+              <div
+                className="w-12 h-12 rounded-2xl flex items-center justify-center mb-5"
+                style={{
+                  background: `${accentHex}15`,
+                  color: accentHex,
+                  border: `1px solid ${accentHex}28`,
+                }}
+              >
+                {current.icon}
+              </div>
 
-          {/* Title */}
-          <h2
-            className="text-2xl font-semibold tracking-tight mb-3"
-            style={{ color: step === 0 || isLast ? accentHex : 'white' }}
-          >
-            {current.title}
-          </h2>
+              {/* Title */}
+              <h2
+                className="text-2xl font-semibold tracking-tight mb-3"
+                style={{ color: step === 0 || isLast ? accentHex : 'white' }}
+              >
+                {current.title}
+              </h2>
 
-          {/* Description */}
-          <p className="text-zinc-400 text-sm leading-relaxed mb-8">
-            {current.desc}
-          </p>
+              {/* Description */}
+              <p className="text-zinc-400 text-sm leading-relaxed mb-8">
+                {current.desc}
+              </p>
+            </motion.div>
+          </AnimatePresence>
 
           {/* Actions */}
           <div className="flex items-center justify-between gap-3">
@@ -141,12 +313,9 @@ export function Tour({ onClose, accentHex = '#D7FE51' }: TourProps) {
               <button
                 onClick={next}
                 className="px-6 py-2.5 rounded-xl text-sm font-semibold transition-all active:scale-[0.97] hover:opacity-90"
-                style={{
-                  background: accentHex,
-                  color: isDark ? '#000' : '#fff',
-                }}
+                style={{ background: accentHex, color: isDark ? '#000' : '#fff' }}
               >
-                {isLast ? 'Get started →' : 'Next →'}
+                {isLast ? 'Get started' : 'Next'}
               </button>
             </div>
           </div>
@@ -167,8 +336,8 @@ export function Tour({ onClose, accentHex = '#D7FE51' }: TourProps) {
               />
             ))}
           </div>
-        </motion.div>
-      </AnimatePresence>
+        </div>
+      </motion.div>
     </div>
   )
 }


### PR DESCRIPTION
Closes #113

## Changes

- **Tour no-blink fix:** card stays mounted, only content crossfades
- **Sidebar pointer:** tour box positions next to the sidebar item it describes, with an arrow and glow highlight
- **Emoji replacement:** all emojis replaced with clean inline SVG icons across Tour, FeaturePreview, Rewards, ClockWidget, BreakReminderModal, App

Generated with [Claude Code](https://claude.ai/code)