### PR TITLE
ui: redesign logo — solid bolt hands, full circle border, remove W shape and speed lines

### DIFF
--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -59,9 +59,11 @@
       <circle cx="78" cy="25" r="2.5" opacity="0.6"/>
     </g>
 
-    <!-- Lightning bolt hands — bold angular zigzags -->
-    <path d="M 100 100 L 84 72 L 95 65 L 70 40" stroke="white" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M 100 100 L 116 72 L 105 65 L 130 40" stroke="white" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+    <!-- Lightning bolt hands — solid filled polygon shapes -->
+    <!-- Hour hand: pointing to ~10 o'clock (upper-left) -->
+    <path d="M 103 97 L 69 78 L 77 68 L 52 65 L 48 70 L 60 74 L 73 84 L 97 103 Z" fill="white"/>
+    <!-- Minute hand: pointing to ~2 o'clock (upper-right, mirror of hour hand) -->
+    <path d="M 97 97 L 131 78 L 123 68 L 148 65 L 152 70 L 140 74 L 127 84 L 103 103 Z" fill="white"/>
 
     <!-- Center pivot -->
     <circle cx="100" cy="100" r="7" fill="white"/>
@@ -72,17 +74,7 @@
 
   </g>
 
-  <!-- Clock ring — bottom 240° arc (10 o'clock → bottom → 2 o'clock) -->
-  <path d="M 24.7 56.5 A 87 87 0 1 1 175.3 56.5" stroke="white" stroke-width="5" fill="none" opacity="0.95"/>
+  <!-- Complete circle border (same weight as SwiftShift font) -->
+  <circle cx="100" cy="100" r="87" stroke="white" stroke-width="5" fill="none" opacity="0.95"/>
 
-  <!-- Arrow IS the top 120° arc of the clock ring (10 o'clock → top → 2 o'clock) -->
-  <path d="M 24.7 56.5 A 87 87 0 0 1 175.3 56.5" stroke="white" stroke-width="5" stroke-linecap="round" fill="none" opacity="0.95"/>
-
-  <!-- Arrowhead at 2 o'clock -->
-  <path d="M 175.3 56.5 L 161 48 L 175 40 Z" fill="white" opacity="0.95"/>
-
-  <!-- Speed/swoosh lines (bottom left) -->
-  <line x1="10" y1="148" x2="55" y2="126" stroke="white" stroke-width="4" stroke-linecap="round" opacity="0.85"/>
-  <line x1="5" y1="162" x2="48" y2="144" stroke="white" stroke-width="3" stroke-linecap="round" opacity="0.6"/>
-  <line x1="12" y1="175" x2="45" y2="161" stroke="white" stroke-width="2" stroke-linecap="round" opacity="0.4"/>
 </svg>


### PR DESCRIPTION
Redesigns logo.svg per issue #126:
- Replaced partial arc + arrowhead with a complete circle border
- Removed speed/swoosh lines from bottom-left
- Replaced stroke zigzag hands with solid filled lightning bolt polygon shapes

Closes #126

Generated with [Claude Code](https://claude.ai/code)