### PR TITLE
ui: center clock-out text, style toasts with theme, add State label, theme achievement icons

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1922,9 +1922,10 @@ export default function App() {
     }
   }, [activeView, user?.id])
 
-  // Persist theme
+  // Persist theme and sync to body for toast styling
   useEffect(() => {
     localStorage.setItem('theme', theme)
+    document.body.setAttribute('data-theme', theme)
   }, [theme])
 
   // Update favicon dynamically when theme changes
@@ -2655,7 +2656,7 @@ export default function App() {
               </svg>
               {navUnlockedAchievements.slice(0, 3).map(id => {
                 const ach = ACHIEVEMENTS.find(a => a.id === id)
-                return ach ? <span key={id} className="text-xs leading-none">{ach.icon}</span> : null
+                return ach ? <span key={id} className="text-xs leading-none" style={{ color: 'var(--accent-color)' }}>{ach.icon}</span> : null
               })}
               <span className="ta-streak-label text-white/40">Achievements</span>
             </button>
@@ -3101,6 +3102,7 @@ export default function App() {
                       </div>
                       {/* Work state selector + break law info below the bar */}
                       <div className="mt-1.5 flex items-center gap-2">
+                        <span className="text-xs text-zinc-400">State:</span>
                         <select
                           value={workState}
                           onChange={e => setWorkState(e.target.value)}

--- a/frontend/src/components/LootDrop.tsx
+++ b/frontend/src/components/LootDrop.tsx
@@ -167,7 +167,8 @@ export function LootDrop({ isOpen, onClose, earnings, ptoHours, durationMin, the
               ×
             </button>
             {/* Funny message */}
-            <div className="text-xl font-semibold tracking-tight text-left leading-tight mb-4 pr-10" style={{ color: accentColor }}>
+            <div className="h-3" />
+            <div className="text-xl font-semibold tracking-tight text-center leading-tight mb-4" style={{ color: accentColor }}>
               {dailyMessage}
             </div>
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -872,7 +872,17 @@ button, [role="button"] {
    ============================================ */
 
 [data-sonner-toast] {
+  background: #000000 !important;
+  border: 1px solid rgba(var(--accent-color-rgb), 0.45) !important;
   box-shadow:
     0 0 40px -10px rgba(var(--accent-color-rgb), 0.25),
     0 8px 24px -4px rgba(0, 0, 0, 0.8) !important;
+}
+
+[data-sonner-toast] [data-title] {
+  color: var(--accent-color) !important;
+}
+
+[data-sonner-toast] [data-description] {
+  color: rgba(255, 255, 255, 0.55) !important;
 }


### PR DESCRIPTION
Resolves #128

- Center "Exit stage left" clock-out message and add top padding
- Toast popups: pure black background, thin theme-colored outline, theme-colored title text
- Add "State:" label left of work-state dropdown on time clock tab
- Achievement pill icons now match active theme color

Generated with [Claude Code](https://claude.ai/code)