### PR TITLE
ui: remove duplicate hand emoji and fix clock-out popup padding

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2148,7 +2148,7 @@ export default function App() {
       const hour = new Date().getHours()
       const g = hour < 12 ? 'morning' : hour < 17 ? 'afternoon' : 'evening'
       setTimeout(() => {
-        toast(`Good ${g}, ${user.first_name}! 👋`, {
+        toast(`Good ${g}, ${user.first_name}!`, {
           description: streak > 0 ? `${streak}-day streak - keep it going!` : 'Ready to clock in?',
           duration: 8000,
           icon: '👋',

--- a/frontend/src/components/LootDrop.tsx
+++ b/frontend/src/components/LootDrop.tsx
@@ -161,13 +161,12 @@ export function LootDrop({ isOpen, onClose, earnings, ptoHours, durationMin, the
             {/* Close X — absolute top-right corner */}
             <button
               onClick={onClose}
-              className="absolute top-3 right-3 w-8 h-8 flex items-center justify-center text-zinc-400 hover:text-white text-2xl leading-none z-10 rounded-lg hover:bg-white/10 transition-colors"
+              className="absolute top-2 right-3 w-8 h-8 flex items-center justify-center text-zinc-400 hover:text-white text-2xl leading-none z-10 rounded-lg hover:bg-white/10 transition-colors"
               aria-label="Close"
             >
               ×
             </button>
             {/* Funny message */}
-            <div className="h-3" />
             <div className="text-xl font-semibold tracking-tight text-center leading-tight mb-4" style={{ color: accentColor }}>
               {dailyMessage}
             </div>


### PR DESCRIPTION
Fixes two UI issues:
- Removed duplicate 👋 emoji from greeting toast (was in both message text and icon)
- Reduced padding above X button on clock-out popup (moved to top-2, removed h-3 spacer)

Closes #130

Generated with [Claude Code](https://claude.ai/code)